### PR TITLE
Fix #15 - Broken link to Docker Hub

### DIFF
--- a/docs/getting-started-openshift.md
+++ b/docs/getting-started-openshift.md
@@ -37,7 +37,7 @@ The following are required to provision AWS services from the OpenShift Service 
 *   OpenShift Container Platform (OCP) or Origin v3.7
 *   Docker
 *   Service Catalog
-*   AWS Service Broker configured with an appropriate registry (e.g. [docker.io/awsservicebroker](https://hub.docker.com/u/awsservicebroker/dashboard/))
+*   AWS Service Broker configured with an appropriate registry (e.g. [docker.io/awsservicebroker](https://hub.docker.com/u/awsservicebroker/))
 *   APB Prerequisites (if applicable)
 
 Instructions below will guide you in deploying these components in production and development environments.


### PR DESCRIPTION
#15
Fixes broken link to Docker Hub.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
