### PR TITLE
Golint

### DIFF
--- a/pkg/broker/api.go
+++ b/pkg/broker/api.go
@@ -367,18 +367,6 @@ func (b *AwsBroker) Bind(request *osb.BindRequest, c *broker.RequestContext) (*b
 	}, nil
 }
 
-func (b *AwsBroker) GetBinding(request *osb.GetBindingRequest, c *broker.RequestContext) (*broker.GetBindingResponse, error) {
-	glog.V(10).Infoln(request)
-	glog.V(10).Infoln(c)
-	return &broker.GetBindingResponse{}, nil
-}
-
-func BindingLastOperation(request *osb.BindingLastOperationRequest, c *broker.RequestContext) (*broker.LastOperationResponse, error) {
-	glog.V(10).Infoln(request)
-	glog.V(10).Infoln(c)
-	return &broker.LastOperationResponse{}, nil
-}
-
 // Unbind is executed when the OSB API receives `DELETE /v2/service_instances/:instance_id/service_bindings/:binding_id`
 // (https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md#request-5).
 func (b *AwsBroker) Unbind(request *osb.UnbindRequest, c *broker.RequestContext) (*broker.UnbindResponse, error) {
@@ -533,6 +521,12 @@ func (b *AwsBroker) Update(request *osb.UpdateInstanceRequest, c *broker.Request
 	return &response, nil
 }
 
+// BindingLastOperation is not implemented, as async binding is not supported.
 func (b *AwsBroker) BindingLastOperation(request *osb.BindingLastOperationRequest, c *broker.RequestContext) (*broker.LastOperationResponse, error) {
-	return &broker.LastOperationResponse{LastOperationResponse: osb.LastOperationResponse{State: "", Description: nil}}, nil
+	panic("not implemented")
+}
+
+// GetBinding is not implemented, as async binding is not supported.
+func (b *AwsBroker) GetBinding(request *osb.GetBindingRequest, c *broker.RequestContext) (*broker.GetBindingResponse, error) {
+	panic("not implemented")
 }

--- a/pkg/broker/aws_sdk.go
+++ b/pkg/broker/aws_sdk.go
@@ -17,7 +17,7 @@ import (
 
 // Create AWS Session
 func AwsSessionGetter(keyid string, secretkey string, region string, accountId string, profile string, params map[string]string) *session.Session {
-	creds := AwsCredentialsGetter(keyid, secretkey, profile, params, ec2metadata.New(session.Must(session.NewSession())))
+	creds := awsCredentialsGetter(keyid, secretkey, profile, params, ec2metadata.New(session.Must(session.NewSession())))
 	cfg := aws.NewConfig().WithCredentials(&creds).WithRegion(region)
 	currentAccountSession := session.Must(session.NewSession(cfg))
 	sess, err := assumeTargetRole(currentAccountSession, params, region, accountId)

--- a/pkg/broker/awsbroker.go
+++ b/pkg/broker/awsbroker.go
@@ -71,7 +71,7 @@ func NewAWSBroker(o Options, awssess GetAwsSession, clients AwsClients, getCalle
 		tablename:          o.TableName,
 		s3bucket:           o.S3Bucket,
 		s3region:           o.S3Region,
-		s3key:              AddTrailingSlash(o.S3Key),
+		s3key:              addTrailingSlash(o.S3Key),
 		templatefilter:     o.TemplateFilter,
 		region:             o.Region,
 		s3svc:              s3svc,

--- a/pkg/broker/awsbroker_test.go
+++ b/pkg/broker/awsbroker_test.go
@@ -168,7 +168,7 @@ func TestNewAwsBroker(t *testing.T) {
 		assert.Equal(v.TableName, bl.tablename)
 		assert.Equal(v.S3Bucket, bl.s3bucket)
 		assert.Equal(v.S3Region, bl.s3region)
-		assert.Equal(AddTrailingSlash(v.S3Key), bl.s3key)
+		assert.Equal(addTrailingSlash(v.S3Key), bl.s3key)
 		assert.Equal(v.TemplateFilter, bl.templatefilter)
 		assert.Equal(v.Region, bl.region)
 		assert.Equal(v.BrokerID, bl.brokerid)

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -148,14 +148,14 @@ func TestGetOverridesFromEnv(t *testing.T) {
 	clearOverrides()
 
 	msg := "should return empty map if there are no overrides set"
-	output := GetOverridesFromEnv()
+	output := getOverridesFromEnv()
 	assertor.Equal(make(map[string]string), output, msg)
 
 	msg = "should return map with all the found overrides, excluding any environment variables not prefixed with PARAM_OVERRIDE_"
 	os.Setenv("PARAM_OVERRIDE_awsservicebroker_all_all_all_test_param1", "testval1")
 	os.Setenv("PARAM_OVERRIDE_awsservicebroker_all_all_all_test_param2", "testval2")
 	os.Setenv("NOTMATCHPARAM_OVERRIDE_awsservicebroker_all_all_all_test_param3", "testval3")
-	output = GetOverridesFromEnv()
+	output = getOverridesFromEnv()
 	assertor.Equal(map[string]string{
 		"awsservicebroker_all_all_all_test_param1": "testval1",
 		"awsservicebroker_all_all_all_test_param2": "testval2",
@@ -215,7 +215,7 @@ func TestAwsCredentialsGetter(t *testing.T) {
 	keyid, secretkey, profile := "", "", ""
 	params := make(map[string]string)
 	client := ec2metadata.New(session.Must(session.NewSession()))
-	actual := AwsCredentialsGetter(keyid, secretkey, profile, params, client)
+	actual := awsCredentialsGetter(keyid, secretkey, profile, params, client)
 	expected := *credentials.NewChainCredentials(
 		[]credentials.Provider{
 			&credentials.EnvProvider{},
@@ -226,18 +226,18 @@ func TestAwsCredentialsGetter(t *testing.T) {
 
 	keyid, secretkey, profile = "testid", "testkey", ""
 	expected = *credentials.NewStaticCredentials(keyid, secretkey, "")
-	actual = AwsCredentialsGetter(keyid, secretkey, profile, params, client)
+	actual = awsCredentialsGetter(keyid, secretkey, profile, params, client)
 	assertor.Equal(expected, actual, "should return static creds")
 
 	keyid, secretkey, profile = "", "", "test"
 	expected = *credentials.NewChainCredentials([]credentials.Provider{&credentials.SharedCredentialsProvider{Profile: profile}})
-	actual = AwsCredentialsGetter(keyid, secretkey, profile, params, client)
+	actual = awsCredentialsGetter(keyid, secretkey, profile, params, client)
 	assertor.Equal(expected, actual, "should return shared creds")
 
 	keyid, secretkey, profile = "", "", ""
 	params = map[string]string{"aws_access_key": "testKeyId", "aws_secret_key": "testSecretKey"}
 	expected = *credentials.NewStaticCredentials("testKeyId", "testSecretKey", "")
-	actual = AwsCredentialsGetter(keyid, secretkey, profile, params, client)
+	actual = awsCredentialsGetter(keyid, secretkey, profile, params, client)
 	assertor.Equal(expected, actual, "should return static creds")
 }
 


### PR DESCRIPTION
## Overview

Gets a clean `golint` run on a couple files: `pkg/broker/api.go` and `pkg/broker/util.go`.

## Notes

The majority of the remaining `golint` warnings are about types in `pkg/broker/aws_sdk.go` and `pkg/broker/types.go` that may not need to be exported. If those should be addressed too, I can tackle that in a future PR.

Ignore whitespace (`?w=1`) when diff-ing. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
