### PR TITLE
Refactor prescribeOverrides

### DIFF
--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -47,6 +47,10 @@ func prescribeOverrides(b AwsBroker, services []osb.Service) []osb.Service {
 				delete(params["properties"].(map[string]interface{}), k)
 				params["required"] = deleteFromSlice(params["required"].([]string), k)
 			}
+			if len(params["required"].([]string)) == 0 {
+				// Cloud Foundry does not allow "required" to be an empty slice
+				delete(params, "required")
+			}
 
 			if plan.Schemas.ServiceInstance.Update != nil {
 				params := plan.Schemas.ServiceInstance.Update.Parameters.(map[string]interface{})
@@ -57,6 +61,9 @@ func prescribeOverrides(b AwsBroker, services []osb.Service) []osb.Service {
 				if len(params["properties"].(map[string]interface{})) == 0 {
 					// If there are no updatable properties left, remove the update schema
 					plan.Schemas.ServiceInstance.Update = nil
+				} else if len(params["required"].([]string)) == 0 {
+					// Cloud Foundry does not allow "required" to be an empty slice
+					delete(params, "required")
 				}
 			}
 		}

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -91,6 +91,7 @@ func TestPrescribeOverrides(t *testing.T) {
 				ServiceInstance: &osb.ServiceInstanceSchema{
 					Create: &osb.InputParametersSchema{
 						Parameters: map[string]interface{}{"type": "object", "properties": map[string]interface{}{
+							"param":          map[string]interface{}{"type": "integer"},
 							"req_param":      map[string]interface{}{"type": "string"},
 							"override_param": map[string]interface{}{"type": "string"},
 						},
@@ -100,6 +101,7 @@ func TestPrescribeOverrides(t *testing.T) {
 					},
 					Update: &osb.InputParametersSchema{
 						Parameters: map[string]interface{}{"type": "object", "properties": map[string]interface{}{
+							"param":          map[string]interface{}{"type": "integer"},
 							"req_param":      map[string]interface{}{"type": "string"},
 							"override_param": map[string]interface{}{"type": "string"},
 						},
@@ -120,6 +122,7 @@ func TestPrescribeOverrides(t *testing.T) {
 				ServiceInstance: &osb.ServiceInstanceSchema{
 					Create: &osb.InputParametersSchema{
 						Parameters: map[string]interface{}{"type": "object", "properties": map[string]interface{}{
+							"param":     map[string]interface{}{"type": "integer"},
 							"req_param": map[string]interface{}{"type": "string"},
 						},
 							"$schema":  "http://json-schema.org/draft-06/schema#",
@@ -128,6 +131,7 @@ func TestPrescribeOverrides(t *testing.T) {
 					},
 					Update: &osb.InputParametersSchema{
 						Parameters: map[string]interface{}{"type": "object", "properties": map[string]interface{}{
+							"param":     map[string]interface{}{"type": "integer"},
 							"req_param": map[string]interface{}{"type": "string"},
 						},
 							"$schema":  "http://json-schema.org/draft-06/schema#",
@@ -139,6 +143,38 @@ func TestPrescribeOverrides(t *testing.T) {
 		}},
 	}
 	assertor.Equal(expected, psvcs, msg)
+
+	msg = "required should be removed if all required params are overridden"
+	b := AwsBroker{
+		brokerid:           "awsservicebroker",
+		prescribeOverrides: true,
+		globalOverrides:    map[string]string{"override_param": "overridden", "req_param": "overridden"},
+	}
+	psvcs = prescribeOverrides(b, services)
+	expected = []osb.Service{
+		{ID: "test", Name: "test", Description: "test", Plans: []osb.Plan{
+			{ID: "testplan", Name: "testplan", Description: "testplan", Schemas: &osb.Schemas{
+				ServiceInstance: &osb.ServiceInstanceSchema{
+					Create: &osb.InputParametersSchema{
+						Parameters: map[string]interface{}{"type": "object", "properties": map[string]interface{}{
+							"param": map[string]interface{}{"type": "integer"},
+						},
+							"$schema": "http://json-schema.org/draft-06/schema#",
+						},
+					},
+					Update: &osb.InputParametersSchema{
+						Parameters: map[string]interface{}{"type": "object", "properties": map[string]interface{}{
+							"param": map[string]interface{}{"type": "integer"},
+						},
+							"$schema": "http://json-schema.org/draft-06/schema#",
+						},
+					},
+				},
+			}},
+		}},
+	}
+	assertor.Equal(expected, psvcs, msg)
+
 	clearOverrides()
 }
 


### PR DESCRIPTION
## Overview

Cleans up the `prescribeOverrides` implementation.

### Notes

With the original implementation, the `TestPrescribeOverrides` test was failing about 10% of the time like this:

```
--- FAIL: TestPrescribeOverrides (0.00s)
	util_test.go:141: 
			Error Trace:	util_test.go:141
			Error:      	Not equal: 
			            	expected: []v2.Service{v2.Service{ID:"test", Name:"test", Description:"test", Tags:[]string(nil), Requires:[]string(nil), Bindable:false, BindingsRetrievable:false, PlanUpdatable:(*bool)(nil), Plans:[]v2.Plan{v2.Plan{ID:"testplan", Name:"testplan", Description:"testplan", Free:(*bool)(nil), Bindable:(*bool)(nil), Metadata:map[string]interface {}(nil), Schemas:(*v2.Schemas)(0xc420387b40)}}, DashboardClient:(*v2.DashboardClient)(nil), Metadata:map[string]interface {}(nil)}}
			            	actual  : []v2.Service{v2.Service{ID:"test", Name:"test", Description:"test", Tags:[]string(nil), Requires:[]string(nil), Bindable:false, BindingsRetrievable:false, PlanUpdatable:(*bool)(nil), Plans:[]v2.Plan{v2.Plan{ID:"testplan", Name:"testplan", Description:"testplan", Free:(*bool)(nil), Bindable:(*bool)(nil), Metadata:map[string]interface {}(nil), Schemas:(*v2.Schemas)(0xc420387af0)}}, DashboardClient:(*v2.DashboardClient)(nil), Metadata:map[string]interface {}(nil)}}
			            	
			            	Diff:
			            	--- Expected
			            	+++ Actual
			            	@@ -34,16 +34,3 @@
			            	       }),
			            	-      Update: (*v2.InputParametersSchema)({
			            	-       Parameters: (map[string]interface {}) (len=4) {
			            	-        (string) (len=7) "$schema": (string) (len=39) "http://json-schema.org/draft-06/schema#",
			            	-        (string) (len=10) "properties": (map[string]interface {}) (len=1) {
			            	-         (string) (len=9) "req_param": (map[string]interface {}) (len=1) {
			            	-          (string) (len=4) "type": (string) (len=6) "string"
			            	-         }
			            	-        },
			            	-        (string) (len=8) "required": ([]string) (len=1) {
			            	-         (string) (len=9) "req_param"
			            	-        },
			            	-        (string) (len=4) "type": (string) (len=6) "object"
			            	-       }
			            	-      })
			            	+      Update: (*v2.InputParametersSchema)(<nil>)
			            	      }),
			Test:       	TestPrescribeOverrides
			Messages:   	override_param should be removed from Update params too when prescribeOverrides is true
```

Rather than get to the root cause of the test failure, it seemed easier to just address the TODO and refactor `prescribeOverrides`. Now, instead of creating new schemas, we just remove the overridden keys from the existing schemas. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
