### PR TITLE
Add Unbind tests

### DIFF
--- a/pkg/broker/awsbroker_test.go
+++ b/pkg/broker/awsbroker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/awstesting/mock"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -85,6 +86,15 @@ func (c *mockIAM) AttachRolePolicy(input *iam.AttachRolePolicyInput) (*iam.Attac
 		return nil, errors.New("test failure")
 	}
 	return &iam.AttachRolePolicyOutput{}, nil
+}
+
+func (c *mockIAM) DetachRolePolicy(input *iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error) {
+	if aws.StringValue(input.RoleName) == "err" || aws.StringValue(input.PolicyArn) == "err" {
+		return nil, errors.New("test failure")
+	} else if aws.StringValue(input.RoleName) == "exists" && aws.StringValue(input.PolicyArn) == "exists" {
+		return &iam.DetachRolePolicyOutput{}, nil
+	}
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "", nil)
 }
 
 func mockAwsIamClientGetter(sess *session.Session) iamiface.IAMAPI {


### PR DESCRIPTION
## Overview

Adds tests for `Unbind`, increasing coverage to 92.9%.

## Notes

```
--- PASS: TestUnbind (0.00s)
    --- PASS: TestUnbind/error_getting_binding (0.00s)
    --- PASS: TestUnbind/binding_not_found (0.00s)
    --- PASS: TestUnbind/success (0.00s)
    --- PASS: TestUnbind/error_getting_instance (0.00s)
    --- PASS: TestUnbind/instance_not_found (0.00s)
    --- PASS: TestUnbind/error_detaching_role_policy (0.00s)
    --- PASS: TestUnbind/detach_role_policy (0.00s)
    --- PASS: TestUnbind/role_not_found (0.00s)
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
