### PR TITLE
Do not panic when there are no required params

### DIFF
--- a/pkg/broker/awsbroker.go
+++ b/pkg/broker/awsbroker.go
@@ -333,10 +333,13 @@ func (db Db) ServiceDefinitionToOsb(sd map[string]interface{}) osb.Service {
 								"type":       "object",
 								"properties": propsForCreate,
 								"$schema":    "http://json-schema.org/draft-06/schema#",
-								"required":   requiredForCreate,
 							},
 						},
 					},
+				}
+				if len(requiredForCreate) > 0 {
+					// Cloud Foundry does not allow "required" to be an empty slice
+					plan.Schemas.ServiceInstance.Create.Parameters.(map[string]interface{})["required"] = requiredForCreate
 				}
 				if len(propsForUpdate) > 0 {
 					plan.Schemas.ServiceInstance.Update = &osb.InputParametersSchema{
@@ -344,8 +347,11 @@ func (db Db) ServiceDefinitionToOsb(sd map[string]interface{}) osb.Service {
 							"type":       "object",
 							"properties": propsForUpdate,
 							"$schema":    "http://json-schema.org/draft-06/schema#",
-							"required":   requiredForUpdate,
 						},
+					}
+					if len(requiredForUpdate) > 0 {
+						// Cloud Foundry does not allow "required" to be an empty slice
+						plan.Schemas.ServiceInstance.Update.Parameters.(map[string]interface{})["required"] = requiredForUpdate
 					}
 				}
 			}

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -45,9 +45,11 @@ func prescribeOverrides(b AwsBroker, services []osb.Service) []osb.Service {
 			params := plan.Schemas.ServiceInstance.Create.Parameters.(map[string]interface{})
 			for _, k := range overridenKeys {
 				delete(params["properties"].(map[string]interface{}), k)
-				params["required"] = deleteFromSlice(params["required"].([]string), k)
+				if params["required"] != nil {
+					params["required"] = deleteFromSlice(params["required"].([]string), k)
+				}
 			}
-			if len(params["required"].([]string)) == 0 {
+			if params["required"] != nil && len(params["required"].([]string)) == 0 {
 				// Cloud Foundry does not allow "required" to be an empty slice
 				delete(params, "required")
 			}
@@ -56,12 +58,14 @@ func prescribeOverrides(b AwsBroker, services []osb.Service) []osb.Service {
 				params := plan.Schemas.ServiceInstance.Update.Parameters.(map[string]interface{})
 				for _, k := range overridenKeys {
 					delete(params["properties"].(map[string]interface{}), k)
-					params["required"] = deleteFromSlice(params["required"].([]string), k)
+					if params["required"] != nil {
+						params["required"] = deleteFromSlice(params["required"].([]string), k)
+					}
 				}
 				if len(params["properties"].(map[string]interface{})) == 0 {
 					// If there are no updatable properties left, remove the update schema
 					plan.Schemas.ServiceInstance.Update = nil
-				} else if len(params["required"].([]string)) == 0 {
+				} else if params["required"] != nil && len(params["required"].([]string)) == 0 {
 					// Cloud Foundry does not allow "required" to be an empty slice
 					delete(params, "required")
 				}

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -175,6 +175,38 @@ func TestPrescribeOverrides(t *testing.T) {
 	}
 	assertor.Equal(expected, psvcs, msg)
 
+	msg = "should succeed when there are no required params"
+	b = AwsBroker{
+		brokerid:           "awsservicebroker",
+		prescribeOverrides: true,
+		globalOverrides:    map[string]string{"override_param": "overridden"},
+	}
+	psvcs = prescribeOverrides(b, []osb.Service{
+		{ID: "test", Name: "test", Description: "test", Plans: []osb.Plan{
+			{ID: "testplan", Name: "testplan", Description: "testplan", Schemas: &osb.Schemas{
+				ServiceInstance: &osb.ServiceInstanceSchema{Create: &osb.InputParametersSchema{
+					Parameters: map[string]interface{}{"type": "object", "properties": map[string]interface{}{
+						"override_param": map[string]interface{}{"type": "string"},
+					},
+						"$schema": "http://json-schema.org/draft-06/schema#",
+					},
+				}},
+			}},
+		}},
+	})
+	expected = []osb.Service{
+		{ID: "test", Name: "test", Description: "test", Plans: []osb.Plan{
+			{ID: "testplan", Name: "testplan", Description: "testplan", Schemas: &osb.Schemas{
+				ServiceInstance: &osb.ServiceInstanceSchema{Create: &osb.InputParametersSchema{
+					Parameters: map[string]interface{}{"type": "object", "properties": map[string]interface{}{},
+						"$schema": "http://json-schema.org/draft-06/schema#",
+					},
+				}},
+			}},
+		}},
+	}
+	assertor.Equal(expected, psvcs, msg)
+
 	clearOverrides()
 }
 

--- a/scripts/start_broker.sh
+++ b/scripts/start_broker.sh
@@ -3,15 +3,20 @@
 # Script to start the broker run by Dockerfile
 #
 aws-servicebroker \
-    -insecure \
-    -alsologtostderr \
-    -region ${AWS_DEFAULT_REGION:=us-west-2} \
-    -s3Bucket ${S3_BUCKET:=awsservicebrokeralpha} \
-    -s3Key ${BUCKET_PREFIX:=pcf/templates} \
-    -s3Region ${BUCKET_REGION:=us-west-2} \
-    -port ${PORT:=3199} \
-    -tableName ${DYNAMO_TABLE:=awssb} \
-    -enableBasicAuth \
-    -basicAuthUser ${SECURITY_USER_NAME:=admin} \
-    -basicAuthPass ${SECURITY_USER_PASSWORD} \
-    -v=${VERBOSE_LEVEL:=4}
+    -logtostderr \
+    -brokerId=${BROKER_ID:=awsservicebroker} \
+    -enableBasicAuth=true \
+    -basicAuthUser=${SECURITY_USER_NAME:=admin} \
+    -basicAuthPass=${SECURITY_USER_PASSWORD} \
+    -insecure=${INSECURE:=false} \
+    -port=${PORT:=3199} \
+    -region=${TABLE_REGION:=us-east-1} \
+    -s3Bucket=${S3_BUCKET:=awsservicebroker} \
+    -s3Key=${S3_KEY:=templates/latest/} \
+    -s3Region=${S3_REGION:=us-east-1} \
+    -tableName=${TABLE_NAME:=aws-service-broker} \
+    -templateFilter=${TEMPLATE_FILTER:=-main.yaml} \
+    -tlsCert=${TLS_CERT} \
+    -tlsKey=${TLS_KEY} \
+    -prescribeOverrides=${PRESCRIBE:=true} \
+    -v=${VERBOSITY:=5}


### PR DESCRIPTION
## Overview

`prescribeOverrides` now verifies that `params["required"]` is not `nil` before asserting that it is a `[]string`. 

Also ensures that `params["required"]` is not an empty slice when `prescribeOverrides` is `false`.

## Related Issues

Fixes #32.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
