### PR TITLE
Allow overriding the target region

### DIFF
--- a/packaging/helm/aws-servicebroker/templates/broker-deployment.yaml
+++ b/packaging/helm/aws-servicebroker/templates/broker-deployment.yaml
@@ -45,6 +45,8 @@ spec:
         - "/var/run/awssb/awssb.crt"
         - --tls-private-key-file
         - "/var/run/awssb/awssb.key"
+        - --region
+        - "{{ .Values.aws.region }}"
         - --s3Bucket
         - "{{ .Values.aws.bucket }}"
         - --s3Key
@@ -82,8 +84,6 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}-credentials
               key: secretkey
-        - name: AWS_DEFAULT_REGION
-          value: {{ .Values.aws.region }}
         - name: PARAM_OVERRIDE_{{ .Values.brokerconfig.brokerid }}_all_all_all_aws_access_key
           valueFrom:
             secretKeyRef:

--- a/pkg/broker/aws_sdk.go
+++ b/pkg/broker/aws_sdk.go
@@ -19,6 +19,11 @@ import (
 
 // Create AWS Session
 func AwsSessionGetter(keyid string, secretkey string, region string, accountId string, profile string, params map[string]string) *session.Session {
+	// Check whether the target region has been overridden
+	if params["region"] != "" {
+		region = params["region"]
+	}
+
 	creds := awsCredentialsGetter(keyid, secretkey, profile, params, ec2metadata.New(session.Must(session.NewSession())))
 	cfg := aws.NewConfig().WithCredentials(&creds).WithRegion(region)
 	currentAccountSession := session.Must(session.NewSession(cfg))


### PR DESCRIPTION
## Overview

- Updates the Helm template to set `region`.
- Allows overriding the target region with a param.

## Related Issues

Fixes #33.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
