### PR TITLE
Restore support for deploying with a role

### DIFF
--- a/pkg/broker/api.go
+++ b/pkg/broker/api.go
@@ -86,8 +86,10 @@ func (b *AwsBroker) Provision(request *osb.ProvisionRequest, c *broker.RequestCo
 	}
 	for k, v := range request.Parameters {
 		if !stringInSlice(k, availableParams) {
-			desc := fmt.Sprintf("The parameter %s is not available.", k)
-			return nil, newHTTPStatusCodeError(http.StatusBadRequest, "", desc)
+			if !stringInSlice(k, nonCfnParams) {
+				desc := fmt.Sprintf("The parameter %s is not available.", k)
+				return nil, newHTTPStatusCodeError(http.StatusBadRequest, "", desc)
+			}
 		}
 		params[k] = paramValue(v)
 	}


### PR DESCRIPTION
## Overview
The [docs](https://github.com/awslabs/aws-servicebroker/tree/master/docs#managing-resources-via-assumed-role) says that it's possible to use an assumed role by providing the `target_account_id` and `target_role_name` configuration values.  This fixes it by only erroring out if it's not a `nonCfnParams` either.

## Related Issues
Fixes #37

## Testing
I deployed `rdsmysql` without and with the change (on [SCF](https://github.com/SUSE/scf/), which is Cloud Foundry on Kubernetes).

## Testing Instructions
- Create a rdsmysql service (with the custom plan) with the following parameters:
```json
    {
        "aws_access_key": "${AWS_ACCESS_KEY}",
        "aws_secret_key": "${AWS_SECRET_KEY}",
        "AccessCidr": "${IP}/32",
        "BackupRetentionPeriod": 0,
        "MasterUsername": "master",
        "DBInstanceClass": "db.t2.micro",
        "PubliclyAccessible": "true",
        "region": "${REGION}",
        "StorageEncrypted": "false",
        "VpcId": "${VPC}",
        "target_account_id": "${ACCOUNT}",
        "target_role_name": "${ROLE}"
    }
```
(The parameters should be filled in, of course.)

## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
