### PR TITLE
Delete service instance after resources are deprovisioned

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,6 +42,7 @@
     "service/cloudformation/cloudformationiface",
     "service/dynamodb",
     "service/dynamodb/dynamodbattribute",
+    "service/dynamodb/expression",
     "service/iam",
     "service/iam/iamiface",
     "service/s3",
@@ -231,6 +232,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "37d2ac1bd3b0cbc92ef8c16fa42dd36347bc8d365e65a94cf87c22485edd666e"
+  inputs-digest = "67b442a5b7a18a2ef82dbcab7f4481046fa9907d70c46abd6403159e701936ee"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -97,6 +97,7 @@ type DataStore interface {
 	GetServiceDefinition(serviceuuid string) (*osb.Service, error)
 	GetServiceInstance(sid string) (*serviceinstance.ServiceInstance, error)
 	PutServiceInstance(si serviceinstance.ServiceInstance) error
+	DeleteServiceInstance(sid string) error
 	GetServiceBinding(id string) (*serviceinstance.ServiceBinding, error)
 	PutServiceBinding(sb serviceinstance.ServiceBinding) error
 	DeleteServiceBinding(id string) error

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/condition.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/condition.go
@@ -1,0 +1,1577 @@
+package expression
+
+import (
+	"fmt"
+	"strings"
+)
+
+// conditionMode specifies the types of the struct conditionBuilder,
+// representing the different types of Conditions (i.e. And, Or, Between, ...)
+type conditionMode int
+
+const (
+	// unsetCond catches errors for unset ConditionBuilder structs
+	unsetCond conditionMode = iota
+	// equalCond represents the Equals Condition
+	equalCond
+	// notEqualCond represents the Not Equals Condition
+	notEqualCond
+	// lessThanCond represents the LessThan Condition
+	lessThanCond
+	// lessThanEqualCond represents the LessThanOrEqual Condition
+	lessThanEqualCond
+	// greaterThanCond represents the GreaterThan Condition
+	greaterThanCond
+	// greaterThanEqualCond represents the GreaterThanEqual Condition
+	greaterThanEqualCond
+	// andCond represents the Logical And Condition
+	andCond
+	// orCond represents the Logical Or Condition
+	orCond
+	// notCond represents the Logical Not Condition
+	notCond
+	// betweenCond represents the Between Condition
+	betweenCond
+	// inCond represents the In Condition
+	inCond
+	// attrExistsCond represents the Attribute Exists Condition
+	attrExistsCond
+	// attrNotExistsCond represents the Attribute Not Exists Condition
+	attrNotExistsCond
+	// attrTypeCond represents the Attribute Type Condition
+	attrTypeCond
+	// beginsWithCond represents the Begins With Condition
+	beginsWithCond
+	// containsCond represents the Contains Condition
+	containsCond
+)
+
+// DynamoDBAttributeType specifies the type of an DynamoDB item attribute. This
+// enum is used in the AttributeType() function in order to be explicit about
+// the DynamoDB type that is being checked and ensure compile time checks.
+// More Informatin at http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions
+type DynamoDBAttributeType string
+
+const (
+	// String represents the DynamoDB String type
+	String DynamoDBAttributeType = "S"
+	// StringSet represents the DynamoDB String Set type
+	StringSet = "SS"
+	// Number represents the DynamoDB Number type
+	Number = "N"
+	// NumberSet represents the DynamoDB Number Set type
+	NumberSet = "NS"
+	// Binary represents the DynamoDB Binary type
+	Binary = "B"
+	// BinarySet represents the DynamoDB Binary Set type
+	BinarySet = "BS"
+	// Boolean represents the DynamoDB Boolean type
+	Boolean = "BOOL"
+	// Null represents the DynamoDB Null type
+	Null = "NULL"
+	// List represents the DynamoDB List type
+	List = "L"
+	// Map represents the DynamoDB Map type
+	Map = "M"
+)
+
+// ConditionBuilder represents Condition Expressions and Filter Expressions
+// in DynamoDB. ConditionBuilders are one of the building blocks of the Builder
+// struct. Since Filter Expressions support all the same functions and formats
+// as Condition Expressions, ConditionBuilders represents both types of
+// Expressions.
+// More Information at: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html
+// More Information on Filter Expressions: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.FilterExpression
+type ConditionBuilder struct {
+	operandList   []OperandBuilder
+	conditionList []ConditionBuilder
+	mode          conditionMode
+}
+
+// Equal returns a ConditionBuilder representing the equality clause of the two
+// argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the equal clause of the item attribute "foo" and
+//     // the value 5
+//     condition := expression.Equal(expression.Name("foo"), expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Equal(expression.Name("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo = :five"
+func Equal(left, right OperandBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		operandList: []OperandBuilder{left, right},
+		mode:        equalCond,
+	}
+}
+
+// Equal returns a ConditionBuilder representing the equality clause of the two
+// argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the equal clause of the item attribute "foo" and
+//     // the value 5
+//     condition := expression.Name("foo").Equal(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("foo").Equal(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo = :five"
+func (nb NameBuilder) Equal(right OperandBuilder) ConditionBuilder {
+	return Equal(nb, right)
+}
+
+// Equal returns a ConditionBuilder representing the equality clause of the two
+// argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the equal clause of the item attribute "foo" and
+//     // the value 5
+//     condition := expression.Value(5).Equal(expression.Name("foo"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Value(5).Equal(expression.Name("foo"))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     ":five = foo"
+func (vb ValueBuilder) Equal(right OperandBuilder) ConditionBuilder {
+	return Equal(vb, right)
+}
+
+// Equal returns a ConditionBuilder representing the equality clause of the two
+// argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the equal clause of the size of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.Size(expression.Name("foo")).Equal(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Size(expression.Name("foo")).Equal(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "size (foo) = :five"
+func (sb SizeBuilder) Equal(right OperandBuilder) ConditionBuilder {
+	return Equal(sb, right)
+}
+
+// NotEqual returns a ConditionBuilder representing the not equal clause of the
+// two argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the not equal clause of the item attribute "foo"
+//     // and the value 5
+//     condition := expression.NotEqual(expression.Name("foo"), expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.NotEqual(expression.Name("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo <> :five"
+func NotEqual(left, right OperandBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		operandList: []OperandBuilder{left, right},
+		mode:        notEqualCond,
+	}
+}
+
+// NotEqual returns a ConditionBuilder representing the not equal clause of the
+// two argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the not equal clause of the item attribute "foo"
+//     // and the value 5
+//     condition := expression.Name("foo").NotEqual(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("foo").NotEqual(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo <> :five"
+func (nb NameBuilder) NotEqual(right OperandBuilder) ConditionBuilder {
+	return NotEqual(nb, right)
+}
+
+// NotEqual returns a ConditionBuilder representing the not equal clause of the
+// two argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the not equal clause of the item attribute "foo"
+//     // and the value 5
+//     condition := expression.Value(5).NotEqual(expression.Name("foo"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Value(5).NotEqual(expression.Name("foo"))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     ":five <> foo"
+func (vb ValueBuilder) NotEqual(right OperandBuilder) ConditionBuilder {
+	return NotEqual(vb, right)
+}
+
+// NotEqual returns a ConditionBuilder representing the not equal clause of the
+// two argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the not equal clause of the size of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.Size(expression.Name("foo")).NotEqual(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Size(expression.Name("foo")).NotEqual(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "size (foo) <> :five"
+func (sb SizeBuilder) NotEqual(right OperandBuilder) ConditionBuilder {
+	return NotEqual(sb, right)
+}
+
+// LessThan returns a ConditionBuilder representing the less than clause of the
+// two argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the less than clause of the item attribute "foo"
+//     // and the value 5
+//     condition := expression.LessThan(expression.Name("foo"), expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.LessThan(expression.Name("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo < :five"
+func LessThan(left, right OperandBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		operandList: []OperandBuilder{left, right},
+		mode:        lessThanCond,
+	}
+}
+
+// LessThan returns a ConditionBuilder representing the less than clause of the
+// two argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the less than clause of the item attribute "foo"
+//     // and the value 5
+//     condition := expression.Name("foo").LessThan(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("foo").LessThan(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo < :five"
+func (nb NameBuilder) LessThan(right OperandBuilder) ConditionBuilder {
+	return LessThan(nb, right)
+}
+
+// LessThan returns a ConditionBuilder representing the less than clause of the
+// two argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the less than clause of the item attribute "foo"
+//     // and the value 5
+//     condition := expression.Value(5).LessThan(expression.Name("foo"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Value(5).LessThan(expression.Name("foo"))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     ":five < foo"
+func (vb ValueBuilder) LessThan(right OperandBuilder) ConditionBuilder {
+	return LessThan(vb, right)
+}
+
+// LessThan returns a ConditionBuilder representing the less than clause of the
+// two argument OperandBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the less than clause of the size of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.Size(expression.Name("foo")).LessThan(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Size(expression.Name("foo")).LessThan(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "size (foo) < :five"
+func (sb SizeBuilder) LessThan(right OperandBuilder) ConditionBuilder {
+	return LessThan(sb, right)
+}
+
+// LessThanEqual returns a ConditionBuilder representing the less than equal to
+// clause of the two argument OperandBuilders. The resulting ConditionBuilder
+// can be used as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the less than equal to clause of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.LessThanEqual(expression.Name("foo"), expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.LessThanEqual(expression.Name("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo <= :five"
+func LessThanEqual(left, right OperandBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		operandList: []OperandBuilder{left, right},
+		mode:        lessThanEqualCond,
+	}
+}
+
+// LessThanEqual returns a ConditionBuilder representing the less than equal to
+// clause of the two argument OperandBuilders. The resulting ConditionBuilder
+// can be used as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the less than equal to clause of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.Name("foo").LessThanEqual(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("foo").LessThanEqual(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo <= :five"
+func (nb NameBuilder) LessThanEqual(right OperandBuilder) ConditionBuilder {
+	return LessThanEqual(nb, right)
+}
+
+// LessThanEqual returns a ConditionBuilder representing the less than equal to
+// clause of the two argument OperandBuilders. The resulting ConditionBuilder
+// can be used as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the less than equal to clause of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.Value(5).LessThanEqual(expression.Name("foo"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Value(5).LessThanEqual(expression.Name("foo"))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     ":five <= foo"
+func (vb ValueBuilder) LessThanEqual(right OperandBuilder) ConditionBuilder {
+	return LessThanEqual(vb, right)
+}
+
+// LessThanEqual returns a ConditionBuilder representing the less than equal to
+// clause of the two argument OperandBuilders. The resulting ConditionBuilder
+// can be used as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the less than equal to clause of the size of the
+//     // item attribute "foo" and the value 5
+//     condition := expression.Size(expression.Name("foo")).LessThanEqual(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Size(expression.Name("foo")).LessThanEqual(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "size (foo) <= :five"
+func (sb SizeBuilder) LessThanEqual(right OperandBuilder) ConditionBuilder {
+	return LessThanEqual(sb, right)
+}
+
+// GreaterThan returns a ConditionBuilder representing the greater than clause
+// of the two argument OperandBuilders. The resulting ConditionBuilder can be
+// used as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the greater than clause of the item attribute
+//     // "foo" and the value 5
+//     condition := expression.GreaterThan(expression.Name("foo"), expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.GreaterThan(expression.Name("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo > :five"
+func GreaterThan(left, right OperandBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		operandList: []OperandBuilder{left, right},
+		mode:        greaterThanCond,
+	}
+}
+
+// GreaterThan returns a ConditionBuilder representing the greater than clause
+// of the two argument OperandBuilders. The resulting ConditionBuilder can be
+// used as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the greater than clause of the item attribute
+//     // "foo" and the value 5
+//     condition := expression.Name("foo").GreaterThan(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("foo").GreaterThan(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo > :five"
+func (nb NameBuilder) GreaterThan(right OperandBuilder) ConditionBuilder {
+	return GreaterThan(nb, right)
+}
+
+// GreaterThan returns a ConditionBuilder representing the greater than clause
+// of the two argument OperandBuilders. The resulting ConditionBuilder can be
+// used as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the greater than clause of the item attribute
+//     // "foo" and the value 5
+//     condition := expression.Value(5).GreaterThan(expression.Name("foo"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Value(5).GreaterThan(expression.Name("foo"))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     ":five > foo"
+func (vb ValueBuilder) GreaterThan(right OperandBuilder) ConditionBuilder {
+	return GreaterThan(vb, right)
+}
+
+// GreaterThan returns a ConditionBuilder representing the greater than
+// clause of the two argument OperandBuilders. The resulting ConditionBuilder
+// can be used as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the greater than clause of the size of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.Size(expression.Name("foo")).GreaterThan(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Size(expression.Name("foo")).GreaterThan(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "size (foo) > :five"
+func (sb SizeBuilder) GreaterThan(right OperandBuilder) ConditionBuilder {
+	return GreaterThan(sb, right)
+}
+
+// GreaterThanEqual returns a ConditionBuilder representing the greater than
+// equal to clause of the two argument OperandBuilders. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the greater than equal to clause of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.GreaterThanEqual(expression.Name("foo"), expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.GreaterThanEqual(expression.Name("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo >= :five"
+func GreaterThanEqual(left, right OperandBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		operandList: []OperandBuilder{left, right},
+		mode:        greaterThanEqualCond,
+	}
+}
+
+// GreaterThanEqual returns a ConditionBuilder representing the greater than
+// equal to clause of the two argument OperandBuilders. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the greater than equal to clause of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.Name("foo").GreaterThanEqual(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("foo").GreaterThanEqual(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo >= :five"
+func (nb NameBuilder) GreaterThanEqual(right OperandBuilder) ConditionBuilder {
+	return GreaterThanEqual(nb, right)
+}
+
+// GreaterThanEqual returns a ConditionBuilder representing the greater than
+// equal to clause of the two argument OperandBuilders. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the greater than equal to clause of the item
+//     // attribute "foo" and the value 5
+//     condition := expression.Value(5).GreaterThanEqual(expression.Name("foo"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Value(5).GreaterThanEqual(expression.Name("foo"))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     ":five >= foo"
+func (vb ValueBuilder) GreaterThanEqual(right OperandBuilder) ConditionBuilder {
+	return GreaterThanEqual(vb, right)
+}
+
+// GreaterThanEqual returns a ConditionBuilder representing the greater than
+// equal to clause of the two argument OperandBuilders. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the greater than equal to clause of the size of
+//     // the item attribute "foo" and the value 5
+//     condition := expression.Size(expression.Name("foo")).GreaterThanEqual(expression.Value(5))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Size(expression.Name("foo")).GreaterThanEqual(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "size (foo) >= :five"
+func (sb SizeBuilder) GreaterThanEqual(right OperandBuilder) ConditionBuilder {
+	return GreaterThanEqual(sb, right)
+}
+
+// And returns a ConditionBuilder representing the logical AND clause of the
+// argument ConditionBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct. Note that And() can take a variadic number of
+// ConditionBuilders as arguments.
+//
+// Example:
+//
+//     // condition represents the condition where the item attribute "Name" is
+//     // equal to value "Generic Name" AND the item attribute "Age" is less
+//     // than value 40
+//     condition := expression.And(expression.Name("Name").Equal(expression.Value("Generic Name")), expression.Name("Age").LessThan(expression.Value(40)))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.And(expression.Name("Name").Equal(expression.Value("Generic Name")), expression.Name("Age").LessThan(expression.Value(40)))
+//     // Let #NAME, :name, and :forty be ExpressionAttributeName and
+//     // ExpressionAttributeValues representing the item attribute "Name", the
+//     // value "Generic Name", and the value 40
+//     "(#NAME = :name) AND (Age < :forty)"
+func And(left, right ConditionBuilder, other ...ConditionBuilder) ConditionBuilder {
+	other = append([]ConditionBuilder{left, right}, other...)
+	return ConditionBuilder{
+		conditionList: other,
+		mode:          andCond,
+	}
+}
+
+// And returns a ConditionBuilder representing the logical AND clause of the
+// argument ConditionBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct. Note that And() can take a variadic number of
+// ConditionBuilders as arguments.
+//
+// Example:
+//
+//     // condition represents the condition where the item attribute "Name" is
+//     // equal to value "Generic Name" AND the item attribute "Age" is less
+//     // than value 40
+//     condition := expression.Name("Name").Equal(expression.Value("Generic Name")).And(expression.Name("Age").LessThan(expression.Value(40)))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("Name").Equal(expression.Value("Generic Name")).And(expression.Name("Age").LessThan(expression.Value(40)))
+//     // Let #NAME, :name, and :forty be ExpressionAttributeName and
+//     // ExpressionAttributeValues representing the item attribute "Name", the
+//     // value "Generic Name", and the value 40
+//     "(#NAME = :name) AND (Age < :forty)"
+func (cb ConditionBuilder) And(right ConditionBuilder, other ...ConditionBuilder) ConditionBuilder {
+	return And(cb, right, other...)
+}
+
+// Or returns a ConditionBuilder representing the logical OR clause of the
+// argument ConditionBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct. Note that Or() can take a variadic number of
+// ConditionBuilders as arguments.
+//
+// Example:
+//
+//     // condition represents the condition where the item attribute "Price" is
+//     // less than the value 100 OR the item attribute "Rating" is greater than
+//     // the value 8
+//     condition := expression.Or(expression.Name("Price").Equal(expression.Value(100)), expression.Name("Rating").LessThan(expression.Value(8)))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Or(expression.Name("Price").Equal(expression.Value(100)), expression.Name("Rating").LessThan(expression.Value(8)))
+//     // Let :price and :rating be ExpressionAttributeValues representing the
+//     // the value 100 and value 8 respectively
+//     "(Price < :price) OR (Rating > :rating)"
+func Or(left, right ConditionBuilder, other ...ConditionBuilder) ConditionBuilder {
+	other = append([]ConditionBuilder{left, right}, other...)
+	return ConditionBuilder{
+		conditionList: other,
+		mode:          orCond,
+	}
+}
+
+// Or returns a ConditionBuilder representing the logical OR clause of the
+// argument ConditionBuilders. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct. Note that Or() can take a variadic number of
+// ConditionBuilders as arguments.
+//
+// Example:
+//
+//     // condition represents the condition where the item attribute "Price" is
+//     // less than the value 100 OR the item attribute "Rating" is greater than
+//     // the value 8
+//     condition := expression.Name("Price").Equal(expression.Value(100)).Or(expression.Name("Rating").LessThan(expression.Value(8)))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("Price").Equal(expression.Value(100)).Or(expression.Name("Rating").LessThan(expression.Value(8)))
+//     // Let :price and :rating be ExpressionAttributeValues representing the
+//     // the value 100 and value 8 respectively
+//     "(Price < :price) OR (Rating > :rating)"
+func (cb ConditionBuilder) Or(right ConditionBuilder, other ...ConditionBuilder) ConditionBuilder {
+	return Or(cb, right, other...)
+}
+
+// Not returns a ConditionBuilder representing the logical NOT clause of the
+// argument ConditionBuilder. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the item attribute "Name"
+//     // does not begin with "test"
+//     condition := expression.Not(expression.Name("Name").BeginsWith("test"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Not(expression.Name("Name").BeginsWith("test"))
+//     // Let :prefix be an ExpressionAttributeValue representing the value
+//     // "test"
+//     "NOT (begins_with (:prefix))"
+func Not(conditionBuilder ConditionBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		conditionList: []ConditionBuilder{conditionBuilder},
+		mode:          notCond,
+	}
+}
+
+// Not returns a ConditionBuilder representing the logical NOT clause of the
+// argument ConditionBuilder. The resulting ConditionBuilder can be used as a
+// part of other Condition Expressions or as an argument to the WithCondition()
+// method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the item attribute "Name"
+//     // does not begin with "test"
+//     condition := expression.Name("Name").BeginsWith("test").Not()
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("Name").BeginsWith("test").Not()
+//     // Let :prefix be an ExpressionAttributeValue representing the value
+//     // "test"
+//     "NOT (begins_with (:prefix))"
+func (cb ConditionBuilder) Not() ConditionBuilder {
+	return Not(cb)
+}
+
+// Between returns a ConditionBuilder representing the result of the
+// BETWEEN function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the value of the item
+//     // attribute "Rating" is between values 5 and 10
+//     condition := expression.Between(expression.Name("Rating"), expression.Value(5), expression.Value(10))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Between(expression.Name("Rating"), expression.Value(5), expression.Value(10))
+//     // Let :five and :ten be ExpressionAttributeValues representing the value
+//     // 5 and the value 10
+//     "Rating BETWEEN :five AND :ten"
+func Between(op, lower, upper OperandBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		operandList: []OperandBuilder{op, lower, upper},
+		mode:        betweenCond,
+	}
+}
+
+// Between returns a ConditionBuilder representing the result of the
+// BETWEEN function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the value of the item
+//     // attribute "Rating" is between values 5 and 10
+//     condition := expression.Name("Rating").Between(expression.Value(5), expression.Value(10))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("Rating").Between(expression.Value(5), expression.Value(10))
+//     // Let :five and :ten be ExpressionAttributeValues representing the value
+//     // 5 and the value 10
+//     "Rating BETWEEN :five AND :ten"
+func (nb NameBuilder) Between(lower, upper OperandBuilder) ConditionBuilder {
+	return Between(nb, lower, upper)
+}
+
+// Between returns a ConditionBuilder representing the result of the
+// BETWEEN function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the value 6 is between values
+//     // 5 and 10
+//     condition := expression.Value(6).Between(expression.Value(5), expression.Value(10))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Value(6).Between(expression.Value(5), expression.Value(10))
+//     // Let :six, :five and :ten be ExpressionAttributeValues representing the
+//     // values 6, 5, and 10 respectively
+//     ":six BETWEEN :five AND :ten"
+func (vb ValueBuilder) Between(lower, upper OperandBuilder) ConditionBuilder {
+	return Between(vb, lower, upper)
+}
+
+// Between returns a ConditionBuilder representing the result of the
+// BETWEEN function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the size of the item
+//     // attribute "InviteList" is between values 5 and 10
+//     condition := expression.Size(expression.Name("InviteList")).Between(expression.Value(5), expression.Value(10))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Size(expression.Name("InviteList")).Between(expression.Value(5), expression.Value(10))
+//     // Let :five and :ten be ExpressionAttributeValues representing the value
+//     // 5 and the value 10
+//     "size (InviteList) BETWEEN :five AND :ten"
+func (sb SizeBuilder) Between(lower, upper OperandBuilder) ConditionBuilder {
+	return Between(sb, lower, upper)
+}
+
+// In returns a ConditionBuilder representing the result of the IN function
+// in DynamoDB Condition Expressions. The resulting ConditionBuilder can be used
+// as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the value of the item
+//     // attribute "Color" is checked against the list of colors "red",
+//     // "green", and "blue".
+//     condition := expression.In(expression.Name("Color"), expression.Value("red"), expression.Value("green"), expression.Value("blue"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.In(expression.Name("Color"), expression.Value("red"), expression.Value("green"), expression.Value("blue"))
+//     // Let :red, :green, :blue be ExpressionAttributeValues representing the
+//     // values "red", "green", and "blue" respectively
+//     "Color IN (:red, :green, :blue)"
+func In(left, right OperandBuilder, other ...OperandBuilder) ConditionBuilder {
+	other = append([]OperandBuilder{left, right}, other...)
+	return ConditionBuilder{
+		operandList: other,
+		mode:        inCond,
+	}
+}
+
+// In returns a ConditionBuilder representing the result of the IN function
+// in DynamoDB Condition Expressions. The resulting ConditionBuilder can be used
+// as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the value of the item
+//     // attribute "Color" is checked against the list of colors "red",
+//     // "green", and "blue".
+//     condition := expression.Name("Color").In(expression.Value("red"), expression.Value("green"), expression.Value("blue"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("Color").In(expression.Value("red"), expression.Value("green"), expression.Value("blue"))
+//     // Let :red, :green, :blue be ExpressionAttributeValues representing the
+//     // values "red", "green", and "blue" respectively
+//     "Color IN (:red, :green, :blue)"
+func (nb NameBuilder) In(right OperandBuilder, other ...OperandBuilder) ConditionBuilder {
+	return In(nb, right, other...)
+}
+
+// In returns a ConditionBuilder representing the result of the IN function
+// TODO change this one
+// in DynamoDB Condition Expressions. The resulting ConditionBuilder can be used
+// as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the value "yellow" is checked
+//     // against the list of colors "red", "green", and "blue".
+//     condition := expression.Value("yellow").In(expression.Value("red"), expression.Value("green"), expression.Value("blue"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Value("yellow").In(expression.Value("red"), expression.Value("green"), expression.Value("blue"))
+//     // Let :yellow, :red, :green, :blue be ExpressionAttributeValues
+//     // representing the values "yellow", "red", "green", and "blue"
+//     // respectively
+//     ":yellow IN (:red, :green, :blue)"
+func (vb ValueBuilder) In(right OperandBuilder, other ...OperandBuilder) ConditionBuilder {
+	return In(vb, right, other...)
+}
+
+// In returns a ConditionBuilder representing the result of the IN function
+// in DynamoDB Condition Expressions. The resulting ConditionBuilder can be used
+// as a part of other Condition Expressions or as an argument to the
+// WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the condition where the size of the item
+//     // attribute "Donuts" is checked against the list of numbers 12, 24, and
+//     // 36.
+//     condition := expression.Size(expression.Name("Donuts")).In(expression.Value(12), expression.Value(24), expression.Value(36))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Size(expression.Name("Donuts")).In(expression.Value(12), expression.Value(24), expression.Value(36))
+//     // Let :dozen, :twoDozen, :threeDozen be ExpressionAttributeValues
+//     // representing the values 12, 24, and 36 respectively
+//     "size (Donuts) IN (12, 24, 36)"
+func (sb SizeBuilder) In(right OperandBuilder, other ...OperandBuilder) ConditionBuilder {
+	return In(sb, right, other...)
+}
+
+// AttributeExists returns a ConditionBuilder representing the result of the
+// attribute_exists function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "Age" exists or not
+//     condition := expression.AttributeExists(expression.Name("Age"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.AttributeExists(expression.Name("Age"))
+//     "attribute_exists (Age))"
+func AttributeExists(nameBuilder NameBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		operandList: []OperandBuilder{nameBuilder},
+		mode:        attrExistsCond,
+	}
+}
+
+// AttributeExists returns a ConditionBuilder representing the result of the
+// attribute_exists function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "Age" exists or not
+//     condition := expression.Name("Age").AttributeExists()
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("Age").AttributeExists()
+//     "attribute_exists (Age))"
+func (nb NameBuilder) AttributeExists() ConditionBuilder {
+	return AttributeExists(nb)
+}
+
+// AttributeNotExists returns a ConditionBuilder representing the result of
+// the attribute_not_exists function in DynamoDB Condition Expressions. The
+// resulting ConditionBuilder can be used as a part of other Condition
+// Expressions or as an argument to the WithCondition() method for the Builder
+// struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "Age" exists or not
+//     condition := expression.AttributeNotExists(expression.Name("Age"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.AttributeNotExists(expression.Name("Age"))
+//     "attribute_not_exists (Age))"
+func AttributeNotExists(nameBuilder NameBuilder) ConditionBuilder {
+	return ConditionBuilder{
+		operandList: []OperandBuilder{nameBuilder},
+		mode:        attrNotExistsCond,
+	}
+}
+
+// AttributeNotExists returns a ConditionBuilder representing the result of
+// the attribute_not_exists function in DynamoDB Condition Expressions. The
+// resulting ConditionBuilder can be used as a part of other Condition
+// Expressions or as an argument to the WithCondition() method for the Builder
+// struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "Age" exists or not
+//     condition := expression.Name("Age").AttributeNotExists()
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("Age").AttributeNotExists()
+//     "attribute_not_exists (Age))"
+func (nb NameBuilder) AttributeNotExists() ConditionBuilder {
+	return AttributeNotExists(nb)
+}
+
+// AttributeType returns a ConditionBuilder representing the result of the
+// attribute_type function in DynamoDB Condition Expressions. The DynamoDB types
+// are represented by the type DynamoDBAttributeType. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "Age" has the DynamoDB type Number or not
+//     condition := expression.AttributeType(expression.Name("Age"), expression.Number)
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.AttributeType(expression.Name("Age"), expression.Number)
+//     // Let :type be an ExpressionAttributeValue representing the value "N"
+//     "attribute_type (Age, :type)"
+func AttributeType(nameBuilder NameBuilder, attributeType DynamoDBAttributeType) ConditionBuilder {
+	v := ValueBuilder{
+		value: string(attributeType),
+	}
+	return ConditionBuilder{
+		operandList: []OperandBuilder{nameBuilder, v},
+		mode:        attrTypeCond,
+	}
+}
+
+// AttributeType returns a ConditionBuilder representing the result of the
+// attribute_type function in DynamoDB Condition Expressions. The DynamoDB types
+// are represented by the type DynamoDBAttributeType. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "Age" has the DynamoDB type Number or not
+//     condition := expression.Name("Age").AttributeType(expression.Number)
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("Age").AttributeType(expression.Number)
+//     // Let :type be an ExpressionAttributeValue representing the value "N"
+//     "attribute_type (Age, :type)"
+func (nb NameBuilder) AttributeType(attributeType DynamoDBAttributeType) ConditionBuilder {
+	return AttributeType(nb, attributeType)
+}
+
+// BeginsWith returns a ConditionBuilder representing the result of the
+// begins_with function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "CodeName" starts with the substring "Ben"
+//     condition := expression.BeginsWith(expression.Name("CodeName"), "Ben")
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.BeginsWith(expression.Name("CodeName"), "Ben")
+//     // Let :ben be an ExpressionAttributeValue representing the value "Ben"
+//     "begins_with (CodeName, :ben)"
+func BeginsWith(nameBuilder NameBuilder, prefix string) ConditionBuilder {
+	v := ValueBuilder{
+		value: prefix,
+	}
+	return ConditionBuilder{
+		operandList: []OperandBuilder{nameBuilder, v},
+		mode:        beginsWithCond,
+	}
+}
+
+// BeginsWith returns a ConditionBuilder representing the result of the
+// begins_with function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "CodeName" starts with the substring "Ben"
+//     condition := expression.Name("CodeName").BeginsWith("Ben")
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("CodeName").BeginsWith("Ben")
+//     // Let :ben be an ExpressionAttributeValue representing the value "Ben"
+//     "begins_with (CodeName, :ben)"
+func (nb NameBuilder) BeginsWith(prefix string) ConditionBuilder {
+	return BeginsWith(nb, prefix)
+}
+
+// Contains returns a ConditionBuilder representing the result of the
+// contains function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "InviteList" has the value "Ben"
+//     condition := expression.Contains(expression.Name("InviteList"), expression.Value("Ben"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Contains(expression.Name("InviteList"), expression.Value("Ben"))
+//     // Let :ben be an ExpressionAttributeValue representing the value "Ben"
+//     "contains (InviteList, :ben)"
+func Contains(nameBuilder NameBuilder, substr string) ConditionBuilder {
+	v := ValueBuilder{
+		value: substr,
+	}
+	return ConditionBuilder{
+		operandList: []OperandBuilder{nameBuilder, v},
+		mode:        containsCond,
+	}
+}
+
+// Contains returns a ConditionBuilder representing the result of the
+// contains function in DynamoDB Condition Expressions. The resulting
+// ConditionBuilder can be used as a part of other Condition Expressions or as
+// an argument to the WithCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // condition represents the boolean condition of whether the item
+//     // attribute "InviteList" has the value "Ben"
+//     condition := expression.Name("InviteList").Contains(expression.Value("Ben"))
+//
+//     // Used in another Condition Expression
+//     anotherCondition := expression.Not(condition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithCondition(condition)
+//
+// Expression Equivalent:
+//
+//     expression.Name("InviteList").Contains(expression.Value("Ben"))
+//     // Let :ben be an ExpressionAttributeValue representing the value "Ben"
+//     "contains (InviteList, :ben)"
+func (nb NameBuilder) Contains(substr string) ConditionBuilder {
+	return Contains(nb, substr)
+}
+
+// buildTree builds a tree structure of exprNodes based on the tree
+// structure of the input ConditionBuilder's child ConditionBuilders and
+// OperandBuilders. buildTree() satisfies the treeBuilder interface so
+// ConditionBuilder can be a part of Builder and Expression struct.
+func (cb ConditionBuilder) buildTree() (exprNode, error) {
+	childNodes, err := cb.buildChildNodes()
+	if err != nil {
+		return exprNode{}, err
+	}
+	ret := exprNode{
+		children: childNodes,
+	}
+
+	switch cb.mode {
+	case equalCond, notEqualCond, lessThanCond, lessThanEqualCond, greaterThanCond, greaterThanEqualCond:
+		return compareBuildCondition(cb.mode, ret)
+	case andCond, orCond:
+		return compoundBuildCondition(cb, ret)
+	case notCond:
+		return notBuildCondition(ret)
+	case betweenCond:
+		return betweenBuildCondition(ret)
+	case inCond:
+		return inBuildCondition(cb, ret)
+	case attrExistsCond:
+		return attrExistsBuildCondition(ret)
+	case attrNotExistsCond:
+		return attrNotExistsBuildCondition(ret)
+	case attrTypeCond:
+		return attrTypeBuildCondition(ret)
+	case beginsWithCond:
+		return beginsWithBuildCondition(ret)
+	case containsCond:
+		return containsBuildCondition(ret)
+	case unsetCond:
+		return exprNode{}, newUnsetParameterError("buildTree", "ConditionBuilder")
+	default:
+		return exprNode{}, fmt.Errorf("build condition error: unsupported mode: %v", cb.mode)
+	}
+}
+
+// compareBuildCondition is the function to make exprNodes from Compare
+// ConditionBuilders. compareBuildCondition is only called by the
+// buildTree method. This function assumes that the argument ConditionBuilder
+// has the right format.
+func compareBuildCondition(conditionMode conditionMode, node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	switch conditionMode {
+	case equalCond:
+		node.fmtExpr = "$c = $c"
+	case notEqualCond:
+		node.fmtExpr = "$c <> $c"
+	case lessThanCond:
+		node.fmtExpr = "$c < $c"
+	case lessThanEqualCond:
+		node.fmtExpr = "$c <= $c"
+	case greaterThanCond:
+		node.fmtExpr = "$c > $c"
+	case greaterThanEqualCond:
+		node.fmtExpr = "$c >= $c"
+	default:
+		return exprNode{}, fmt.Errorf("build compare condition error: unsupported mode: %v", conditionMode)
+	}
+
+	return node, nil
+}
+
+// compoundBuildCondition is the function to make exprNodes from And/Or
+// ConditionBuilders. compoundBuildCondition is only called by the
+// buildTree method. This function assumes that the argument ConditionBuilder
+// has the right format.
+func compoundBuildCondition(conditionBuilder ConditionBuilder, node exprNode) (exprNode, error) {
+	// create a string with escaped characters to substitute them with proper
+	// aliases during runtime
+	var mode string
+	switch conditionBuilder.mode {
+	case andCond:
+		mode = " AND "
+	case orCond:
+		mode = " OR "
+	default:
+		return exprNode{}, fmt.Errorf("build compound condition error: unsupported mode: %v", conditionBuilder.mode)
+	}
+	node.fmtExpr = "($c)" + strings.Repeat(mode+"($c)", len(conditionBuilder.conditionList)-1)
+
+	return node, nil
+}
+
+// notBuildCondition is the function to make exprNodes from Not
+// ConditionBuilders. notBuildCondition is only called by the
+// buildTree method. This function assumes that the argument ConditionBuilder
+// has the right format.
+func notBuildCondition(node exprNode) (exprNode, error) {
+	// create a string with escaped characters to substitute them with proper
+	// aliases during runtime
+	node.fmtExpr = "NOT ($c)"
+
+	return node, nil
+}
+
+// betweenBuildCondition is the function to make exprNodes from Between
+// ConditionBuilders. BuildCondition is only called by the
+// buildTree method. This function assumes that the argument ConditionBuilder
+// has the right format.
+func betweenBuildCondition(node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	node.fmtExpr = "$c BETWEEN $c AND $c"
+
+	return node, nil
+}
+
+// inBuildCondition is the function to make exprNodes from In
+// ConditionBuilders. inBuildCondition is only called by the
+// buildTree method. This function assumes that the argument ConditionBuilder
+// has the right format.
+func inBuildCondition(conditionBuilder ConditionBuilder, node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	node.fmtExpr = "$c IN ($c" + strings.Repeat(", $c", len(conditionBuilder.operandList)-2) + ")"
+
+	return node, nil
+}
+
+// attrExistsBuildCondition is the function to make exprNodes from
+// AttrExistsCond ConditionBuilders. attrExistsBuildCondition is only
+// called by the buildTree method. This function assumes that the argument
+// ConditionBuilder has the right format.
+func attrExistsBuildCondition(node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	node.fmtExpr = "attribute_exists ($c)"
+
+	return node, nil
+}
+
+// attrNotExistsBuildCondition is the function to make exprNodes from
+// AttrNotExistsCond ConditionBuilders. attrNotExistsBuildCondition is only
+// called by the buildTree method. This function assumes that the argument
+// ConditionBuilder has the right format.
+func attrNotExistsBuildCondition(node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	node.fmtExpr = "attribute_not_exists ($c)"
+
+	return node, nil
+}
+
+// attrTypeBuildCondition is the function to make exprNodes from AttrTypeCond
+// ConditionBuilders. attrTypeBuildCondition is only called by the
+// buildTree method. This function assumes that the argument
+// ConditionBuilder has the right format.
+func attrTypeBuildCondition(node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	node.fmtExpr = "attribute_type ($c, $c)"
+
+	return node, nil
+}
+
+// beginsWithBuildCondition is the function to make exprNodes from
+// BeginsWithCond ConditionBuilders. beginsWithBuildCondition is only
+// called by the buildTree method. This function assumes that the argument
+// ConditionBuilder has the right format.
+func beginsWithBuildCondition(node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	node.fmtExpr = "begins_with ($c, $c)"
+
+	return node, nil
+}
+
+// containsBuildCondition is the function to make exprNodes from
+// ContainsCond ConditionBuilders. containsBuildCondition is only
+// called by the buildTree method. This function assumes that the argument
+// ConditionBuilder has the right format.
+func containsBuildCondition(node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	node.fmtExpr = "contains ($c, $c)"
+
+	return node, nil
+}
+
+// buildChildNodes creates the list of the child exprNodes. This avoids
+// duplication of code amongst the various buildTree functions.
+func (cb ConditionBuilder) buildChildNodes() ([]exprNode, error) {
+	childNodes := make([]exprNode, 0, len(cb.conditionList)+len(cb.operandList))
+	for _, condition := range cb.conditionList {
+		node, err := condition.buildTree()
+		if err != nil {
+			return []exprNode{}, err
+		}
+		childNodes = append(childNodes, node)
+	}
+	for _, ope := range cb.operandList {
+		operand, err := ope.BuildOperand()
+		if err != nil {
+			return []exprNode{}, err
+		}
+		childNodes = append(childNodes, operand.exprNode)
+	}
+
+	return childNodes, nil
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/doc.go
@@ -1,0 +1,48 @@
+/*
+Package expression provides types and functions to create Amazon DynamoDB
+Expression strings, ExpressionAttributeNames maps, and ExpressionAttributeValues
+maps.
+
+Using the Package
+
+The package represents the various DynamoDB Expressions as structs named
+accordingly. For example, ConditionBuilder represents a DynamoDB Condition
+Expression, an UpdateBuilder represents a DynamoDB Update Expression, and so on.
+The following example shows a sample ConditionExpression and how to build an
+equilvalent ConditionBuilder
+
+  // Let :a be an ExpressionAttributeValue representing the string "No One You
+  // Know"
+  condExpr := "Artist = :a"
+  condBuilder := expression.Name("Artist").Equal(expression.Value("No One You Know"))
+
+In order to retrieve the formatted DynamoDB Expression strings, call the getter
+methods on the Expression struct. To create the Expression struct, call the
+Build() method on the Builder struct. Because some input structs, such as
+QueryInput, can have multiple DynamoDB Expressions, multiple structs
+representing various DynamoDB Expressions can be added to the Builder struct.
+The following example shows a generic usage of the whole package.
+
+  filt := expression.Name("Artist").Equal(expression.Value("No One You Know"))
+  proj := expression.NamesList(expression.Name("SongTitle"), expression.Name("AlbumTitle"))
+  expr, err := expression.NewBuilder().WithFilter(filt).WithProjection(proj).Build()
+  if err != nil {
+    fmt.Println(err)
+  }
+
+  input := &dynamodb.ScanInput{
+    ExpressionAttributeNames:  expr.Names(),
+    ExpressionAttributeValues: expr.Values(),
+    FilterExpression:          expr.Filter(),
+    ProjectionExpression:      expr.Projection(),
+    TableName:                 aws.String("Music"),
+  }
+
+The ExpressionAttributeNames and ExpressionAttributeValues member of the input
+struct must always be assigned when using the Expression struct because all item
+attribute names and values are aliased. That means that if the
+ExpressionAttributeNames and ExpressionAttributeValues member is not assigned
+with the corresponding Names() and Values() methods, the DynamoDB operation will
+run into a logic error.
+*/
+package expression

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/error.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/error.go
@@ -1,0 +1,59 @@
+package expression
+
+import (
+	"fmt"
+)
+
+// InvalidParameterError is returned if invalid parameters are encountered. This
+// error specifically refers to situations where parameters are non-empty but
+// have an invalid syntax/format. The error message includes the function
+// that returned the error originally and the parameter type that was deemed
+// invalid.
+//
+// Example:
+//
+//     // err is of type InvalidParameterError
+//     _, err := expression.Name("foo..bar").BuildOperand()
+type InvalidParameterError struct {
+	parameterType string
+	functionName  string
+}
+
+func (ipe InvalidParameterError) Error() string {
+	return fmt.Sprintf("%s error: invalid parameter: %s", ipe.functionName, ipe.parameterType)
+}
+
+func newInvalidParameterError(funcName, paramType string) InvalidParameterError {
+	return InvalidParameterError{
+		parameterType: paramType,
+		functionName:  funcName,
+	}
+}
+
+// UnsetParameterError is returned if parameters are empty and uninitialized.
+// This error is returned if opaque structs (ConditionBuilder, NameBuilder,
+// Builder, etc) are initialized outside of functions in the package, since all
+// structs in the package are designed to be initialized with functions.
+//
+// Example:
+//
+//     // err is of type UnsetParameterError
+//     _, err := expression.Builder{}.Build()
+//     _, err := expression.NewBuilder().
+//                 WithCondition(expression.ConditionBuilder{}).
+//                 Build()
+type UnsetParameterError struct {
+	parameterType string
+	functionName  string
+}
+
+func (upe UnsetParameterError) Error() string {
+	return fmt.Sprintf("%s error: unset parameter: %s", upe.functionName, upe.parameterType)
+}
+
+func newUnsetParameterError(funcName, paramType string) UnsetParameterError {
+	return UnsetParameterError{
+		parameterType: paramType,
+		functionName:  funcName,
+	}
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/expression.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/expression.go
@@ -1,0 +1,638 @@
+package expression
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+// expressionType specifies the type of Expression. Declaring this type is used
+// to eliminate magic strings
+type expressionType string
+
+const (
+	projection   expressionType = "projection"
+	keyCondition                = "keyCondition"
+	condition                   = "condition"
+	filter                      = "filter"
+	update                      = "update"
+)
+
+// Implement the Sort interface
+type typeList []expressionType
+
+func (l typeList) Len() int {
+	return len(l)
+}
+
+func (l typeList) Less(i, j int) bool {
+	return string(l[i]) < string(l[j])
+}
+
+func (l typeList) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+// Builder represents the struct that builds the Expression struct. Methods such
+// as WithProjection() and WithCondition() can add different kinds of DynamoDB
+// Expressions to the Builder. The method Build() creates an Expression struct
+// with the specified types of DynamoDB Expressions.
+//
+// Example:
+//
+//     keyCond := expression.Key("someKey").Equal(expression.Value("someValue"))
+//     proj := expression.NamesList(expression.Name("aName"), expression.Name("anotherName"), expression.Name("oneOtherName"))
+//
+//     builder := expression.NewBuilder().WithKeyCondition(keyCond).WithProjection(proj)
+//     expression := builder.Build()
+//
+//     queryInput := dynamodb.QueryInput{
+//       KeyConditionExpression:    expression.KeyCondition(),
+//       ProjectionExpression:      expression.Projection(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       TableName: aws.String("SomeTable"),
+//     }
+type Builder struct {
+	expressionMap map[expressionType]treeBuilder
+}
+
+// NewBuilder returns an empty Builder struct. Methods such as WithProjection()
+// and WithCondition() can add different kinds of DynamoDB Expressions to the
+// Builder. The method Build() creates an Expression struct with the specified
+// types of DynamoDB Expressions.
+//
+// Example:
+//
+//     keyCond := expression.Key("someKey").Equal(expression.Value("someValue"))
+//     proj := expression.NamesList(expression.Name("aName"), expression.Name("anotherName"), expression.Name("oneOtherName"))
+//     builder := expression.NewBuilder().WithKeyCondition(keyCond).WithProjection(proj)
+func NewBuilder() Builder {
+	return Builder{}
+}
+
+// Build builds an Expression struct representing multiple types of DynamoDB
+// Expressions. Getter methods on the resulting Expression struct returns the
+// DynamoDB Expression strings as well as the maps that correspond to
+// ExpressionAttributeNames and ExpressionAttributeValues. Calling Build() on an
+// empty Builder returns the typed error EmptyParameterError.
+//
+// Example:
+//
+//     // keyCond represents the Key Condition Expression
+//     keyCond := expression.Key("someKey").Equal(expression.Value("someValue"))
+//     // proj represents the Projection Expression
+//     proj := expression.NamesList(expression.Name("aName"), expression.Name("anotherName"), expression.Name("oneOtherName"))
+//
+//     // Add keyCond and proj to builder as a Key Condition and Projection
+//     // respectively
+//     builder := expression.NewBuilder().WithKeyCondition(keyCond).WithProjection(proj)
+//     expression := builder.Build()
+//
+//     queryInput := dynamodb.QueryInput{
+//       KeyConditionExpression:    expression.KeyCondition(),
+//       ProjectionExpression:      expression.Projection(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       TableName: aws.String("SomeTable"),
+//     }
+func (b Builder) Build() (Expression, error) {
+	if b.expressionMap == nil {
+		return Expression{}, newUnsetParameterError("Build", "Builder")
+	}
+
+	aliasList, expressionMap, err := b.buildChildTrees()
+	if err != nil {
+		return Expression{}, err
+	}
+
+	expression := Expression{
+		expressionMap: expressionMap,
+	}
+
+	if len(aliasList.namesList) != 0 {
+		namesMap := map[string]*string{}
+		for ind, val := range aliasList.namesList {
+			namesMap[fmt.Sprintf("#%v", ind)] = aws.String(val)
+		}
+		expression.namesMap = namesMap
+	}
+
+	if len(aliasList.valuesList) != 0 {
+		valuesMap := map[string]*dynamodb.AttributeValue{}
+		for i := 0; i < len(aliasList.valuesList); i++ {
+			valuesMap[fmt.Sprintf(":%v", i)] = &aliasList.valuesList[i]
+		}
+		expression.valuesMap = valuesMap
+	}
+
+	return expression, nil
+}
+
+// buildChildTrees compiles the list of treeBuilders that are the children of
+// the argument Builder. The returned aliasList represents all the alias tokens
+// used in the expression strings. The returned map[string]string maps the type
+// of expression (i.e. "condition", "update") to the appropriate expression
+// string.
+func (b Builder) buildChildTrees() (aliasList, map[expressionType]string, error) {
+	aList := aliasList{}
+	formattedExpressions := map[expressionType]string{}
+	keys := typeList{}
+
+	for expressionType := range b.expressionMap {
+		keys = append(keys, expressionType)
+	}
+
+	sort.Sort(keys)
+
+	for _, key := range keys {
+		node, err := b.expressionMap[key].buildTree()
+		if err != nil {
+			return aliasList{}, nil, err
+		}
+		formattedExpression, err := node.buildExpressionString(&aList)
+		if err != nil {
+			return aliasList{}, nil, err
+		}
+		formattedExpressions[key] = formattedExpression
+	}
+
+	return aList, formattedExpressions, nil
+}
+
+// WithCondition method adds the argument ConditionBuilder as a Condition
+// Expression to the argument Builder. If the argument Builder already has a
+// ConditionBuilder representing a Condition Expression, WithCondition()
+// overwrites the existing ConditionBuilder.
+//
+// Example:
+//
+//     // let builder be an existing Builder{} and cond be an existing
+//     // ConditionBuilder{}
+//     builder = builder.WithCondition(cond)
+//
+//     // add other DynamoDB Expressions to the builder. let proj be an already
+//     // existing ProjectionBuilder
+//     builder = builder.WithProjection(proj)
+//     // create an Expression struct
+//     expression := builder.Build()
+func (b Builder) WithCondition(conditionBuilder ConditionBuilder) Builder {
+	if b.expressionMap == nil {
+		b.expressionMap = map[expressionType]treeBuilder{}
+	}
+	b.expressionMap[condition] = conditionBuilder
+	return b
+}
+
+// WithProjection method adds the argument ProjectionBuilder as a Projection
+// Expression to the argument Builder. If the argument Builder already has a
+// ProjectionBuilder representing a Projection Expression, WithProjection()
+// overwrites the existing ProjectionBuilder.
+//
+// Example:
+//
+//     // let builder be an existing Builder{} and proj be an existing
+//     // ProjectionBuilder{}
+//     builder = builder.WithProjection(proj)
+//
+//     // add other DynamoDB Expressions to the builder. let cond be an already
+//     // existing ConditionBuilder
+//     builder = builder.WithCondition(cond)
+//     // create an Expression struct
+//     expression := builder.Build()
+func (b Builder) WithProjection(projectionBuilder ProjectionBuilder) Builder {
+	if b.expressionMap == nil {
+		b.expressionMap = map[expressionType]treeBuilder{}
+	}
+	b.expressionMap[projection] = projectionBuilder
+	return b
+}
+
+// WithKeyCondition method adds the argument KeyConditionBuilder as a Key
+// Condition Expression to the argument Builder. If the argument Builder already
+// has a KeyConditionBuilder representing a Key Condition Expression,
+// WithKeyCondition() overwrites the existing KeyConditionBuilder.
+//
+// Example:
+//
+//     // let builder be an existing Builder{} and keyCond be an existing
+//     // KeyConditionBuilder{}
+//     builder = builder.WithKeyCondition(keyCond)
+//
+//     // add other DynamoDB Expressions to the builder. let cond be an already
+//     // existing ConditionBuilder
+//     builder = builder.WithCondition(cond)
+//     // create an Expression struct
+//     expression := builder.Build()
+func (b Builder) WithKeyCondition(keyConditionBuilder KeyConditionBuilder) Builder {
+	if b.expressionMap == nil {
+		b.expressionMap = map[expressionType]treeBuilder{}
+	}
+	b.expressionMap[keyCondition] = keyConditionBuilder
+	return b
+}
+
+// WithFilter method adds the argument ConditionBuilder as a Filter Expression
+// to the argument Builder. If the argument Builder already has a
+// ConditionBuilder representing a Filter Expression, WithFilter()
+// overwrites the existing ConditionBuilder.
+//
+// Example:
+//
+//     // let builder be an existing Builder{} and filt be an existing
+//     // ConditionBuilder{}
+//     builder = builder.WithFilter(filt)
+//
+//     // add other DynamoDB Expressions to the builder. let cond be an already
+//     // existing ConditionBuilder
+//     builder = builder.WithCondition(cond)
+//     // create an Expression struct
+//     expression := builder.Build()
+func (b Builder) WithFilter(filterBuilder ConditionBuilder) Builder {
+	if b.expressionMap == nil {
+		b.expressionMap = map[expressionType]treeBuilder{}
+	}
+	b.expressionMap[filter] = filterBuilder
+	return b
+}
+
+// WithUpdate method adds the argument UpdateBuilder as an Update Expression
+// to the argument Builder. If the argument Builder already has a UpdateBuilder
+// representing a Update Expression, WithUpdate() overwrites the existing
+// UpdateBuilder.
+//
+// Example:
+//
+//     // let builder be an existing Builder{} and update be an existing
+//     // UpdateBuilder{}
+//     builder = builder.WithUpdate(update)
+//
+//     // add other DynamoDB Expressions to the builder. let cond be an already
+//     // existing ConditionBuilder
+//     builder = builder.WithCondition(cond)
+//     // create an Expression struct
+//     expression := builder.Build()
+func (b Builder) WithUpdate(updateBuilder UpdateBuilder) Builder {
+	if b.expressionMap == nil {
+		b.expressionMap = map[expressionType]treeBuilder{}
+	}
+	b.expressionMap[update] = updateBuilder
+	return b
+}
+
+// Expression represents a collection of DynamoDB Expressions. The getter
+// methods of the Expression struct retrieves the formatted DynamoDB
+// Expressions, ExpressionAttributeNames, and ExpressionAttributeValues.
+//
+// Example:
+//
+//     // keyCond represents the Key Condition Expression
+//     keyCond := expression.Key("someKey").Equal(expression.Value("someValue"))
+//     // proj represents the Projection Expression
+//     proj := expression.NamesList(expression.Name("aName"), expression.Name("anotherName"), expression.Name("oneOtherName"))
+//
+//     // Add keyCond and proj to builder as a Key Condition and Projection
+//     // respectively
+//     builder := expression.NewBuilder().WithKeyCondition(keyCond).WithProjection(proj)
+//     expression := builder.Build()
+//
+//     queryInput := dynamodb.QueryInput{
+//       KeyConditionExpression:    expression.KeyCondition(),
+//       ProjectionExpression:      expression.Projection(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       TableName: aws.String("SomeTable"),
+//     }
+type Expression struct {
+	expressionMap map[expressionType]string
+	namesMap      map[string]*string
+	valuesMap     map[string]*dynamodb.AttributeValue
+}
+
+// treeBuilder interface is fulfilled by builder structs that represent
+// different types of Expressions.
+type treeBuilder interface {
+	// buildTree creates the tree structure of exprNodes. The tree structure
+	// of exprNodes are traversed in order to build the string representing
+	// different types of Expressions as well as the maps that represent
+	// ExpressionAttributeNames and ExpressionAttributeValues.
+	buildTree() (exprNode, error)
+}
+
+// Condition returns the *string corresponding to the Condition Expression
+// of the argument Expression. This method is used to satisfy the members of
+// DynamoDB input structs. If the Expression does not have a condition
+// expression this method returns nil.
+//
+// Example:
+//
+//     // let expression be an instance of Expression{}
+//
+//     deleteInput := dynamodb.DeleteItemInput{
+//       ConditionExpression:       expression.Condition(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       Key: map[string]*dynamodb.AttributeValue{
+//         "PartitionKey": &dynamodb.AttributeValue{
+//           S: aws.String("SomeKey"),
+//         },
+//       },
+//       TableName: aws.String("SomeTable"),
+//     }
+func (e Expression) Condition() *string {
+	return e.returnExpression(condition)
+}
+
+// Filter returns the *string corresponding to the Filter Expression of the
+// argument Expression. This method is used to satisfy the members of DynamoDB
+// input structs. If the Expression does not have a filter expression this
+// method returns nil.
+//
+// Example:
+//
+//     // let expression be an instance of Expression{}
+//
+//     queryInput := dynamodb.QueryInput{
+//       KeyConditionExpression:    expression.KeyCondition(),
+//       FilterExpression:          expression.Filter(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       TableName: aws.String("SomeTable"),
+//     }
+func (e Expression) Filter() *string {
+	return e.returnExpression(filter)
+}
+
+// Projection returns the *string corresponding to the Projection Expression
+// of the argument Expression. This method is used to satisfy the members of
+// DynamoDB input structs. If the Expression does not have a projection
+// expression this method returns nil.
+//
+// Example:
+//
+//     // let expression be an instance of Expression{}
+//
+//     queryInput := dynamodb.QueryInput{
+//       KeyConditionExpression:    expression.KeyCondition(),
+//       ProjectionExpression:      expression.Projection(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       TableName: aws.String("SomeTable"),
+//     }
+func (e Expression) Projection() *string {
+	return e.returnExpression(projection)
+}
+
+// KeyCondition returns the *string corresponding to the Key Condition
+// Expression of the argument Expression. This method is used to satisfy the
+// members of DynamoDB input structs. If the argument Expression does not have a
+// KeyConditionExpression, KeyCondition() returns nil.
+//
+// Example:
+//
+//     // let expression be an instance of Expression{}
+//
+//     queryInput := dynamodb.QueryInput{
+//       KeyConditionExpression:    expression.KeyCondition(),
+//       ProjectionExpression:      expression.Projection(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       TableName: aws.String("SomeTable"),
+//     }
+func (e Expression) KeyCondition() *string {
+	return e.returnExpression(keyCondition)
+}
+
+// Update returns the *string corresponding to the Update Expression of the
+// argument Expression. This method is used to satisfy the members of DynamoDB
+// input structs. If the argument Expression does not have a UpdateExpression,
+// Update() returns nil.
+//
+// Example:
+//
+//     // let expression be an instance of Expression{}
+//
+//     updateInput := dynamodb.UpdateInput{
+//       Key: map[string]*dynamodb.AttributeValue{
+//         "PartitionKey": {
+//           S: aws.String("someKey"),
+//         },
+//       },
+//       UpdateExpression:          expression.Update(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       TableName: aws.String("SomeTable"),
+//     }
+func (e Expression) Update() *string {
+	return e.returnExpression(update)
+}
+
+// Names returns the map[string]*string corresponding to the
+// ExpressionAttributeNames of the argument Expression. This method is used to
+// satisfy the members of DynamoDB input structs. If Expression does not use
+// ExpressionAttributeNames, this method returns nil. The
+// ExpressionAttributeNames and ExpressionAttributeValues member of the input
+// struct must always be assigned when using the Expression struct since all
+// item attribute names and values are aliased. That means that if the
+// ExpressionAttributeNames and ExpressionAttributeValues member is not assigned
+// with the corresponding Names() and Values() methods, the DynamoDB operation
+// will run into a logic error.
+//
+// Example:
+//
+//     // let expression be an instance of Expression{}
+//
+//     queryInput := dynamodb.QueryInput{
+//       KeyConditionExpression:    expression.KeyCondition(),
+//       ProjectionExpression:      expression.Projection(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       TableName: aws.String("SomeTable"),
+//     }
+func (e Expression) Names() map[string]*string {
+	return e.namesMap
+}
+
+// Values returns the map[string]*dynamodb.AttributeValue corresponding to
+// the ExpressionAttributeValues of the argument Expression. This method is used
+// to satisfy the members of DynamoDB input structs. If Expression does not use
+// ExpressionAttributeValues, this method returns nil. The
+// ExpressionAttributeNames and ExpressionAttributeValues member of the input
+// struct must always be assigned when using the Expression struct since all
+// item attribute names and values are aliased. That means that if the
+// ExpressionAttributeNames and ExpressionAttributeValues member is not assigned
+// with the corresponding Names() and Values() methods, the DynamoDB operation
+// will run into a logic error.
+//
+// Example:
+//
+//     // let expression be an instance of Expression{}
+//
+//     queryInput := dynamodb.QueryInput{
+//       KeyConditionExpression:    expression.KeyCondition(),
+//       ProjectionExpression:      expression.Projection(),
+//       ExpressionAttributeNames:  expression.Names(),
+//       ExpressionAttributeValues: expression.Values(),
+//       TableName: aws.String("SomeTable"),
+//     }
+func (e Expression) Values() map[string]*dynamodb.AttributeValue {
+	return e.valuesMap
+}
+
+// returnExpression returns *string corresponding to the type of Expression
+// string specified by the expressionType. If there is no corresponding
+// expression available in Expression, the method returns nil
+func (e Expression) returnExpression(expressionType expressionType) *string {
+	if e.expressionMap == nil {
+		return nil
+	}
+	if s, exists := e.expressionMap[expressionType]; exists {
+		return &s
+	}
+	return nil
+}
+
+// exprNode are the generic nodes that represents both Operands and
+// Conditions. The purpose of exprNode is to be able to call an generic
+// recursive function on the top level exprNode to be able to determine a root
+// node in order to deduplicate name aliases.
+// fmtExpr is a string that has escaped characters to refer to
+// names/values/children which needs to be aliased at runtime in order to avoid
+// duplicate values. The rules are as follows:
+//     $n: Indicates that an alias of a name needs to be inserted. The
+//         corresponding name to be alias is in the []names slice.
+//     $v: Indicates that an alias of a value needs to be inserted. The
+//         corresponding value to be alias is in the []values slice.
+//     $c: Indicates that the fmtExpr of a child exprNode needs to be inserted.
+//         The corresponding child node is in the []children slice.
+type exprNode struct {
+	names    []string
+	values   []dynamodb.AttributeValue
+	children []exprNode
+	fmtExpr  string
+}
+
+// aliasList keeps track of all the names we need to alias in the nested
+// struct of conditions and operands. This allows each alias to be unique.
+// aliasList is passed in as a pointer when buildChildTrees is called in
+// order to deduplicate all names within the tree strcuture of the exprNodes.
+type aliasList struct {
+	namesList  []string
+	valuesList []dynamodb.AttributeValue
+}
+
+// buildExpressionString returns a string with aliasing for names/values
+// specified by aliasList. The string corresponds to the expression that the
+// exprNode tree represents.
+func (en exprNode) buildExpressionString(aliasList *aliasList) (string, error) {
+	// Since each exprNode contains a slice of names, values, and children that
+	// correspond to the escaped characters, we an index to traverse the slices
+	index := struct {
+		name, value, children int
+	}{}
+
+	formattedExpression := en.fmtExpr
+
+	for i := 0; i < len(formattedExpression); {
+		if formattedExpression[i] != '$' {
+			i++
+			continue
+		}
+
+		if i == len(formattedExpression)-1 {
+			return "", fmt.Errorf("buildexprNode error: invalid escape character")
+		}
+
+		var alias string
+		var err error
+		// if an escaped character is found, substitute it with the proper alias
+		// TODO consider AST instead of string in the future
+		switch formattedExpression[i+1] {
+		case 'n':
+			alias, err = substitutePath(index.name, en, aliasList)
+			if err != nil {
+				return "", err
+			}
+			index.name++
+
+		case 'v':
+			alias, err = substituteValue(index.value, en, aliasList)
+			if err != nil {
+				return "", err
+			}
+			index.value++
+
+		case 'c':
+			alias, err = substituteChild(index.children, en, aliasList)
+			if err != nil {
+				return "", err
+			}
+			index.children++
+
+		default:
+			return "", fmt.Errorf("buildexprNode error: invalid escape rune %#v", formattedExpression[i+1])
+		}
+		formattedExpression = formattedExpression[:i] + alias + formattedExpression[i+2:]
+		i += len(alias)
+	}
+
+	return formattedExpression, nil
+}
+
+// substitutePath substitutes the escaped character $n with the appropriate
+// alias.
+func substitutePath(index int, node exprNode, aliasList *aliasList) (string, error) {
+	if index >= len(node.names) {
+		return "", fmt.Errorf("substitutePath error: exprNode []names out of range")
+	}
+	str, err := aliasList.aliasPath(node.names[index])
+	if err != nil {
+		return "", err
+	}
+	return str, nil
+}
+
+// substituteValue substitutes the escaped character $v with the appropriate
+// alias.
+func substituteValue(index int, node exprNode, aliasList *aliasList) (string, error) {
+	if index >= len(node.values) {
+		return "", fmt.Errorf("substituteValue error: exprNode []values out of range")
+	}
+	str, err := aliasList.aliasValue(node.values[index])
+	if err != nil {
+		return "", err
+	}
+	return str, nil
+}
+
+// substituteChild substitutes the escaped character $c with the appropriate
+// alias.
+func substituteChild(index int, node exprNode, aliasList *aliasList) (string, error) {
+	if index >= len(node.children) {
+		return "", fmt.Errorf("substituteChild error: exprNode []children out of range")
+	}
+	return node.children[index].buildExpressionString(aliasList)
+}
+
+// aliasValue returns the corresponding alias to the dav value argument. Since
+// values are not deduplicated as of now, all values are just appended to the
+// aliasList and given the index as the alias.
+func (al *aliasList) aliasValue(dav dynamodb.AttributeValue) (string, error) {
+	al.valuesList = append(al.valuesList, dav)
+	return fmt.Sprintf(":%d", len(al.valuesList)-1), nil
+}
+
+// aliasPath returns the corresponding alias to the argument string. The
+// argument is checked against all existing aliasList names in order to avoid
+// duplicate strings getting two different aliases.
+func (al *aliasList) aliasPath(nm string) (string, error) {
+	for ind, name := range al.namesList {
+		if nm == name {
+			return fmt.Sprintf("#%d", ind), nil
+		}
+	}
+	al.namesList = append(al.namesList, nm)
+	return fmt.Sprintf("#%d", len(al.namesList)-1), nil
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/key_condition.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/key_condition.go
@@ -1,0 +1,557 @@
+package expression
+
+import (
+	"fmt"
+)
+
+// keyConditionMode specifies the types of the struct KeyConditionBuilder,
+// representing the different types of KeyConditions (i.e. And, Or, Between, ...)
+type keyConditionMode int
+
+const (
+	// unsetKeyCond catches errors for unset KeyConditionBuilder structs
+	unsetKeyCond keyConditionMode = iota
+	// equalKeyCond represents the Equals KeyCondition
+	equalKeyCond
+	// lessThanKeyCond represents the Less Than KeyCondition
+	lessThanKeyCond
+	// lessThanEqualKeyCond represents the Less Than Or Equal To KeyCondition
+	lessThanEqualKeyCond
+	// greaterThanKeyCond represents the Greater Than KeyCondition
+	greaterThanKeyCond
+	// greaterThanEqualKeyCond represents the Greater Than Or Equal To KeyCondition
+	greaterThanEqualKeyCond
+	// andKeyCond represents the Logical And KeyCondition
+	andKeyCond
+	// betweenKeyCond represents the Between KeyCondition
+	betweenKeyCond
+	// beginsWithKeyCond represents the Begins With KeyCondition
+	beginsWithKeyCond
+)
+
+// KeyConditionBuilder represents Key Condition Expressions in DynamoDB.
+// KeyConditionBuilders are the building blocks of Expressions.
+// More Information at: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.KeyConditionExpressions
+type KeyConditionBuilder struct {
+	operandList      []OperandBuilder
+	keyConditionList []KeyConditionBuilder
+	mode             keyConditionMode
+}
+
+// KeyEqual returns a KeyConditionBuilder representing the equality clause
+// of the two argument OperandBuilders. The resulting KeyConditionBuilder can be
+// used as a part of other Key Condition Expressions or as an argument to the
+// WithKeyCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // keyCondition represents the equal clause of the key "foo" and the
+//     // value 5
+//     keyCondition := expression.KeyEqual(expression.Key("foo"), expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithKeyCondition(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.KeyEqual(expression.Key("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo = :five"
+func KeyEqual(keyBuilder KeyBuilder, valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyConditionBuilder{
+		operandList: []OperandBuilder{keyBuilder, valueBuilder},
+		mode:        equalKeyCond,
+	}
+}
+
+// Equal returns a KeyConditionBuilder representing the equality clause of
+// the two argument OperandBuilders. The resulting KeyConditionBuilder can be
+// used as a part of other Key Condition Expressions or as an argument to the
+// WithKeyCondition() method for the Builder struct.
+//
+// Example:
+//
+//     // keyCondition represents the equal clause of the key "foo" and the
+//     // value 5
+//     keyCondition := expression.Key("foo").Equal(expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithKeyCondition(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.Key("foo").Equal(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo = :five"
+func (kb KeyBuilder) Equal(valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyEqual(kb, valueBuilder)
+}
+
+// KeyLessThan returns a KeyConditionBuilder representing the less than
+// clause of the two argument OperandBuilders. The resulting KeyConditionBuilder
+// can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the less than clause of the key "foo" and the
+//     // value 5
+//     keyCondition := expression.KeyLessThan(expression.Key("foo"), expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.KeyLessThan(expression.Key("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo < :five"
+func KeyLessThan(keyBuilder KeyBuilder, valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyConditionBuilder{
+		operandList: []OperandBuilder{keyBuilder, valueBuilder},
+		mode:        lessThanKeyCond,
+	}
+}
+
+// LessThan returns a KeyConditionBuilder representing the less than clause
+// of the two argument OperandBuilders. The resulting KeyConditionBuilder can be
+// used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the less than clause of the key "foo" and the
+//     // value 5
+//     keyCondition := expression.Key("foo").LessThan(expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.Key("foo").LessThan(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo < :five"
+func (kb KeyBuilder) LessThan(valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyLessThan(kb, valueBuilder)
+}
+
+// KeyLessThanEqual returns a KeyConditionBuilder representing the less than
+// equal to clause of the two argument OperandBuilders. The resulting
+// KeyConditionBuilder can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the less than equal to clause of the key
+//     // "foo" and the value 5
+//     keyCondition := expression.KeyLessThanEqual(expression.Key("foo"), expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.KeyLessThanEqual(expression.Key("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo <= :five"
+func KeyLessThanEqual(keyBuilder KeyBuilder, valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyConditionBuilder{
+		operandList: []OperandBuilder{keyBuilder, valueBuilder},
+		mode:        lessThanEqualKeyCond,
+	}
+}
+
+// LessThanEqual returns a KeyConditionBuilder representing the less than
+// equal to clause of the two argument OperandBuilders. The resulting
+// KeyConditionBuilder can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the less than equal to clause of the key
+//     // "foo" and the value 5
+//     keyCondition := expression.Key("foo").LessThanEqual(expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.Key("foo").LessThanEqual(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo <= :five"
+func (kb KeyBuilder) LessThanEqual(valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyLessThanEqual(kb, valueBuilder)
+}
+
+// KeyGreaterThan returns a KeyConditionBuilder representing the greater
+// than clause of the two argument OperandBuilders. The resulting
+// KeyConditionBuilder can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the greater than clause of the key "foo" and
+//     // the value 5
+//     keyCondition := expression.KeyGreaterThan(expression.Key("foo"), expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.KeyGreaterThan(expression.Key("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo > :five"
+func KeyGreaterThan(keyBuilder KeyBuilder, valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyConditionBuilder{
+		operandList: []OperandBuilder{keyBuilder, valueBuilder},
+		mode:        greaterThanKeyCond,
+	}
+}
+
+// GreaterThan returns a KeyConditionBuilder representing the greater than
+// clause of the two argument OperandBuilders. The resulting KeyConditionBuilder
+// can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // key condition represents the greater than clause of the key "foo" and
+//     // the value 5
+//     keyCondition := expression.Key("foo").GreaterThan(expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.Key("foo").GreaterThan(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo > :five"
+func (kb KeyBuilder) GreaterThan(valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyGreaterThan(kb, valueBuilder)
+}
+
+// KeyGreaterThanEqual returns a KeyConditionBuilder representing the
+// greater than equal to clause of the two argument OperandBuilders. The
+// resulting KeyConditionBuilder can be used as a part of other Key Condition
+// Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the greater than equal to clause of the key
+//     // "foo" and the value 5
+//     keyCondition := expression.KeyGreaterThanEqual(expression.Key("foo"), expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.KeyGreaterThanEqual(expression.Key("foo"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo >= :five"
+func KeyGreaterThanEqual(keyBuilder KeyBuilder, valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyConditionBuilder{
+		operandList: []OperandBuilder{keyBuilder, valueBuilder},
+		mode:        greaterThanEqualKeyCond,
+	}
+}
+
+// GreaterThanEqual returns a KeyConditionBuilder representing the greater
+// than equal to clause of the two argument OperandBuilders. The resulting
+// KeyConditionBuilder can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the greater than equal to clause of the key
+//     // "foo" and the value 5
+//     keyCondition := expression.Key("foo").GreaterThanEqual(expression.Value(5))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.Key("foo").GreaterThanEqual(expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "foo >= :five"
+func (kb KeyBuilder) GreaterThanEqual(valueBuilder ValueBuilder) KeyConditionBuilder {
+	return KeyGreaterThanEqual(kb, valueBuilder)
+}
+
+// KeyAnd returns a KeyConditionBuilder representing the logical AND clause
+// of the two argument KeyConditionBuilders. The resulting KeyConditionBuilder
+// can be used as an argument to the WithKeyCondition() method for the Builder
+// struct.
+//
+// Example:
+//
+//     // keyCondition represents the key condition where the partition key
+//     // "TeamName" is equal to value "Wildcats" and sort key "Number" is equal
+//     // to value 1
+//     keyCondition := expression.KeyAnd(expression.Key("TeamName").Equal(expression.Value("Wildcats")), expression.Key("Number").Equal(expression.Value(1)))
+//
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithKeyCondition(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.KeyAnd(expression.Key("TeamName").Equal(expression.Value("Wildcats")), expression.Key("Number").Equal(expression.Value(1)))
+//     // Let #NUMBER, :teamName, and :one be ExpressionAttributeName and
+//     // ExpressionAttributeValues representing the item attribute "Number",
+//     // the value "Wildcats", and the value 1
+//     "(TeamName = :teamName) AND (#NUMBER = :one)"
+func KeyAnd(left, right KeyConditionBuilder) KeyConditionBuilder {
+	if left.mode != equalKeyCond {
+		return KeyConditionBuilder{
+			mode: andKeyCond,
+		}
+	}
+	if right.mode == andKeyCond {
+		return KeyConditionBuilder{
+			mode: andKeyCond,
+		}
+	}
+	return KeyConditionBuilder{
+		keyConditionList: []KeyConditionBuilder{left, right},
+		mode:             andKeyCond,
+	}
+}
+
+// And returns a KeyConditionBuilder representing the logical AND clause of
+// the two argument KeyConditionBuilders. The resulting KeyConditionBuilder can
+// be used as an argument to the WithKeyCondition() method for the Builder
+// struct.
+//
+// Example:
+//
+//     // keyCondition represents the key condition where the partition key
+//     // "TeamName" is equal to value "Wildcats" and sort key "Number" is equal
+//     // to value 1
+//     keyCondition := expression.Key("TeamName").Equal(expression.Value("Wildcats")).And(expression.Key("Number").Equal(expression.Value(1)))
+//
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithKeyCondition(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.Key("TeamName").Equal(expression.Value("Wildcats")).And(expression.Key("Number").Equal(expression.Value(1)))
+//     // Let #NUMBER, :teamName, and :one be ExpressionAttributeName and
+//     // ExpressionAttributeValues representing the item attribute "Number",
+//     // the value "Wildcats", and the value 1
+//     "(TeamName = :teamName) AND (#NUMBER = :one)"
+func (kcb KeyConditionBuilder) And(right KeyConditionBuilder) KeyConditionBuilder {
+	return KeyAnd(kcb, right)
+}
+
+// KeyBetween returns a KeyConditionBuilder representing the result of the
+// BETWEEN function in DynamoDB Key Condition Expressions. The resulting
+// KeyConditionBuilder can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the boolean key condition of whether the value
+//     // of the key "foo" is between values 5 and 10
+//     keyCondition := expression.KeyBetween(expression.Key("foo"), expression.Value(5), expression.Value(10))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.KeyBetween(expression.Key("foo"), expression.Value(5), expression.Value(10))
+//     // Let :five and :ten be ExpressionAttributeValues representing the
+//     // values 5 and 10 respectively
+//     "foo BETWEEN :five AND :ten"
+func KeyBetween(keyBuilder KeyBuilder, lower, upper ValueBuilder) KeyConditionBuilder {
+	return KeyConditionBuilder{
+		operandList: []OperandBuilder{keyBuilder, lower, upper},
+		mode:        betweenKeyCond,
+	}
+}
+
+// Between returns a KeyConditionBuilder representing the result of the
+// BETWEEN function in DynamoDB Key Condition Expressions. The resulting
+// KeyConditionBuilder can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the boolean key condition of whether the value
+//     // of the key "foo" is between values 5 and 10
+//     keyCondition := expression.Key("foo").Between(expression.Value(5), expression.Value(10))
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.Key("foo").Between(expression.Value(5), expression.Value(10))
+//     // Let :five and :ten be ExpressionAttributeValues representing the
+//     // values 5 and 10 respectively
+//     "foo BETWEEN :five AND :ten"
+func (kb KeyBuilder) Between(lower, upper ValueBuilder) KeyConditionBuilder {
+	return KeyBetween(kb, lower, upper)
+}
+
+// KeyBeginsWith returns a KeyConditionBuilder representing the result of
+// the begins_with function in DynamoDB Key Condition Expressions. The resulting
+// KeyConditionBuilder can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the boolean key condition of whether the value
+//     // of the key "foo" is begins with the prefix "bar"
+//     keyCondition := expression.KeyBeginsWith(expression.Key("foo"), "bar")
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.KeyBeginsWith(expression.Key("foo"), "bar")
+//     // Let :bar be an ExpressionAttributeValue representing the value "bar"
+//     "begins_with(foo, :bar)"
+func KeyBeginsWith(keyBuilder KeyBuilder, prefix string) KeyConditionBuilder {
+	valueBuilder := ValueBuilder{
+		value: prefix,
+	}
+	return KeyConditionBuilder{
+		operandList: []OperandBuilder{keyBuilder, valueBuilder},
+		mode:        beginsWithKeyCond,
+	}
+}
+
+// BeginsWith returns a KeyConditionBuilder representing the result of the
+// begins_with function in DynamoDB Key Condition Expressions. The resulting
+// KeyConditionBuilder can be used as a part of other Key Condition Expressions.
+//
+// Example:
+//
+//     // keyCondition represents the boolean key condition of whether the value
+//     // of the key "foo" is begins with the prefix "bar"
+//     keyCondition := expression.Key("foo").BeginsWith("bar")
+//
+//     // Used in another Key Condition Expression
+//     anotherKeyCondition := expression.Key("partitionKey").Equal(expression.Value("aValue")).And(keyCondition)
+//
+// Expression Equivalent:
+//
+//     expression.Key("foo").BeginsWith("bar")
+//     // Let :bar be an ExpressionAttributeValue representing the value "bar"
+//     "begins_with(foo, :bar)"
+func (kb KeyBuilder) BeginsWith(prefix string) KeyConditionBuilder {
+	return KeyBeginsWith(kb, prefix)
+}
+
+// buildTree builds a tree structure of exprNodes based on the tree
+// structure of the input KeyConditionBuilder's child KeyConditions/Operands.
+// buildTree() satisfies the treeBuilder interface so KeyConditionBuilder can be
+// a part of Expression struct.
+func (kcb KeyConditionBuilder) buildTree() (exprNode, error) {
+	childNodes, err := kcb.buildChildNodes()
+	if err != nil {
+		return exprNode{}, err
+	}
+	ret := exprNode{
+		children: childNodes,
+	}
+
+	switch kcb.mode {
+	case equalKeyCond, lessThanKeyCond, lessThanEqualKeyCond, greaterThanKeyCond, greaterThanEqualKeyCond:
+		return compareBuildKeyCondition(kcb.mode, ret)
+	case andKeyCond:
+		return andBuildKeyCondition(kcb, ret)
+	case betweenKeyCond:
+		return betweenBuildKeyCondition(ret)
+	case beginsWithKeyCond:
+		return beginsWithBuildKeyCondition(ret)
+	case unsetKeyCond:
+		return exprNode{}, newUnsetParameterError("buildTree", "KeyConditionBuilder")
+	default:
+		return exprNode{}, fmt.Errorf("buildKeyCondition error: unsupported mode: %v", kcb.mode)
+	}
+}
+
+// compareBuildKeyCondition is the function to make exprNodes from Compare
+// KeyConditionBuilders. compareBuildKeyCondition is only called by the
+// buildKeyCondition method. This function assumes that the argument
+// KeyConditionBuilder has the right format.
+func compareBuildKeyCondition(keyConditionMode keyConditionMode, node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	switch keyConditionMode {
+	case equalKeyCond:
+		node.fmtExpr = "$c = $c"
+	case lessThanKeyCond:
+		node.fmtExpr = "$c < $c"
+	case lessThanEqualKeyCond:
+		node.fmtExpr = "$c <= $c"
+	case greaterThanKeyCond:
+		node.fmtExpr = "$c > $c"
+	case greaterThanEqualKeyCond:
+		node.fmtExpr = "$c >= $c"
+	default:
+		return exprNode{}, fmt.Errorf("build compare key condition error: unsupported mode: %v", keyConditionMode)
+	}
+
+	return node, nil
+}
+
+// andBuildKeyCondition is the function to make exprNodes from And
+// KeyConditionBuilders. andBuildKeyCondition is only called by the
+// buildKeyCondition method. This function assumes that the argument
+// KeyConditionBuilder has the right format.
+func andBuildKeyCondition(keyConditionBuilder KeyConditionBuilder, node exprNode) (exprNode, error) {
+	if len(keyConditionBuilder.keyConditionList) == 0 && len(keyConditionBuilder.operandList) == 0 {
+		return exprNode{}, newInvalidParameterError("andBuildKeyCondition", "KeyConditionBuilder")
+	}
+	// create a string with escaped characters to substitute them with proper
+	// aliases during runtime
+	node.fmtExpr = "($c) AND ($c)"
+
+	return node, nil
+}
+
+// betweenBuildKeyCondition is the function to make exprNodes from Between
+// KeyConditionBuilders. betweenBuildKeyCondition is only called by the
+// buildKeyCondition method. This function assumes that the argument
+// KeyConditionBuilder has the right format.
+func betweenBuildKeyCondition(node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	node.fmtExpr = "$c BETWEEN $c AND $c"
+
+	return node, nil
+}
+
+// beginsWithBuildKeyCondition is the function to make exprNodes from
+// BeginsWith KeyConditionBuilders. beginsWithBuildKeyCondition is only
+// called by the buildKeyCondition method. This function assumes that the argument
+// KeyConditionBuilder has the right format.
+func beginsWithBuildKeyCondition(node exprNode) (exprNode, error) {
+	// Create a string with special characters that can be substituted later: $c
+	node.fmtExpr = "begins_with ($c, $c)"
+
+	return node, nil
+}
+
+// buildChildNodes creates the list of the child exprNodes. This avoids
+// duplication of code amongst the various buildConditions.
+func (kcb KeyConditionBuilder) buildChildNodes() ([]exprNode, error) {
+	childNodes := make([]exprNode, 0, len(kcb.keyConditionList)+len(kcb.operandList))
+	for _, keyCondition := range kcb.keyConditionList {
+		node, err := keyCondition.buildTree()
+		if err != nil {
+			return []exprNode{}, err
+		}
+		childNodes = append(childNodes, node)
+	}
+	for _, operand := range kcb.operandList {
+		ope, err := operand.BuildOperand()
+		if err != nil {
+			return []exprNode{}, err
+		}
+		childNodes = append(childNodes, ope.exprNode)
+	}
+
+	return childNodes, nil
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/operand.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/operand.go
@@ -1,0 +1,620 @@
+package expression
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+// ValueBuilder represents an item attribute value operand and implements the
+// OperandBuilder interface. Methods and functions in the package take
+// ValueBuilder as an argument and establishes relationships between operands.
+// ValueBuilder should only be initialized using the function Value().
+//
+// Example:
+//
+//     // Create a ValueBuilder representing the string "aValue"
+//     valueBuilder := expression.Value("aValue")
+type ValueBuilder struct {
+	value interface{}
+}
+
+// NameBuilder represents a name of a top level item attribute or a nested
+// attribute. Since NameBuilder represents a DynamoDB Operand, it implements the
+// OperandBuilder interface. Methods and functions in the package take
+// NameBuilder as an argument and establishes relationships between operands.
+// NameBuilder should only be initialized using the function Name().
+//
+// Example:
+//
+//     // Create a NameBuilder representing the item attribute "aName"
+//     nameBuilder := expression.Name("aName")
+type NameBuilder struct {
+	name string
+}
+
+// SizeBuilder represents the output of the function size ("someName"), which
+// evaluates to the size of the item attribute defined by "someName". Since
+// SizeBuilder represents an operand, SizeBuilder implements the OperandBuilder
+// interface. Methods and functions in the package take SizeBuilder as an
+// argument and establishes relationships between operands. SizeBuilder should
+// only be initialized using the function Size().
+//
+// Example:
+//
+//     // Create a SizeBuilder representing the size of the item attribute
+//     // "aName"
+//     sizeBuilder := expression.Name("aName").Size()
+type SizeBuilder struct {
+	nameBuilder NameBuilder
+}
+
+// KeyBuilder represents either the partition key or the sort key, both of which
+// are top level attributes to some item in DynamoDB. Since KeyBuilder
+// represents an operand, KeyBuilder implements the OperandBuilder interface.
+// Methods and functions in the package take KeyBuilder as an argument and
+// establishes relationships between operands. However, KeyBuilder should only
+// be used to describe Key Condition Expressions. KeyBuilder should only be
+// initialized using the function Key().
+//
+// Example:
+//
+//     // Create a KeyBuilder representing the item key "aKey"
+//     keyBuilder := expression.Key("aKey")
+type KeyBuilder struct {
+	key string
+}
+
+// setValueMode specifies the type of SetValueBuilder. The default value is
+// unsetValue so that an UnsetParameterError when BuildOperand() is called on an
+// empty SetValueBuilder.
+type setValueMode int
+
+const (
+	unsetValue setValueMode = iota
+	plusValueMode
+	minusValueMode
+	listAppendValueMode
+	ifNotExistsValueMode
+)
+
+// SetValueBuilder represents the outcome of operator functions supported by the
+// DynamoDB Set operation. The operator functions are the following:
+//     Plus()  // Represents the "+" operator
+//     Minus() // Represents the "-" operator
+//     ListAppend()
+//     IfNotExists()
+// For documentation on the above functions,
+// see: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET
+// Since SetValueBuilder represents an operand, it implements the OperandBuilder
+// interface. SetValueBuilder structs are used as arguments to the Set()
+// function. SetValueBuilders should only initialize a SetValueBuilder using the
+// functions listed above.
+type SetValueBuilder struct {
+	leftOperand  OperandBuilder
+	rightOperand OperandBuilder
+	mode         setValueMode
+}
+
+// Operand represents an item attribute name or value in DynamoDB. The
+// relationship between Operands specified by various builders such as
+// ConditionBuilders and UpdateBuilders for example is processed internally to
+// write Condition Expressions and Update Expressions respectively.
+type Operand struct {
+	exprNode exprNode
+}
+
+// OperandBuilder represents the idea of Operand which are building blocks to
+// DynamoDB Expressions. Package methods and functions can establish
+// relationships between operands, representing DynamoDB Expressions. The method
+// BuildOperand() is called recursively when the Build() method on the type
+// Builder is called. BuildOperand() should never be called externally.
+// OperandBuilder and BuildOperand() are exported to allow package functions to
+// take an interface as an argument.
+type OperandBuilder interface {
+	BuildOperand() (Operand, error)
+}
+
+// Name creates a NameBuilder. The argument should represent the desired item
+// attribute. It is possible to reference nested item attributes by using
+// square brackets for lists and dots for maps. For documentation on specifying
+// item attributes,
+// see: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.Attributes.html
+//
+// Example:
+//
+//     // Specify a top-level attribute
+//     name := expression.Name("TopLevel")
+//     // Specify a nested attribute
+//     nested := expression.Name("Record[6].SongList")
+//     // Use Name() to create a condition expression
+//     condition := expression.Name("foo").Equal(expression.Name("bar"))
+func Name(name string) NameBuilder {
+	return NameBuilder{
+		name: name,
+	}
+}
+
+// Value creates a ValueBuilder. The argument should represent the desired item
+// attribute. The value is marshalled using the dynamodbattribute package by the
+// Build() method for type Builder.
+//
+// Example:
+//
+//     // Use Value() to create a condition expression
+//     condition := expression.Name("foo").Equal(expression.Value(10))
+func Value(value interface{}) ValueBuilder {
+	return ValueBuilder{
+		value: value,
+	}
+}
+
+// Size creates a SizeBuilder representing the size of the item attribute
+// specified by the argument NameBuilder. Size() is only valid for certain types
+// of item attributes. For documentation,
+// see: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html
+// SizeBuilder is only a valid operand in Condition Expressions and Filter
+// Expressions.
+//
+// Example:
+//
+//     // Use Size() to create a condition expression
+//     condition := expression.Name("foo").Size().Equal(expression.Value(10))
+//
+// Expression Equivalent:
+//
+//     expression.Name("aName").Size()
+//     "size (aName)"
+func (nb NameBuilder) Size() SizeBuilder {
+	return SizeBuilder{
+		nameBuilder: nb,
+	}
+}
+
+// Size creates a SizeBuilder representing the size of the item attribute
+// specified by the argument NameBuilder. Size() is only valid for certain types
+// of item attributes. For documentation,
+// see: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html
+// SizeBuilder is only a valid operand in Condition Expressions and Filter
+// Expressions.
+//
+// Example:
+//
+//     // Use Size() to create a condition expression
+//     condition := expression.Size(expression.Name("foo")).Equal(expression.Value(10))
+//
+// Expression Equivalent:
+//
+//     expression.Size(expression.Name("aName"))
+//     "size (aName)"
+func Size(nameBuilder NameBuilder) SizeBuilder {
+	return nameBuilder.Size()
+}
+
+// Key creates a KeyBuilder. The argument should represent the desired partition
+// key or sort key value. KeyBuilders should only be used to specify
+// relationships for Key Condition Expressions. When referring to the partition
+// key or sort key in any other Expression, use Name().
+//
+// Example:
+//
+//     // Use Key() to create a key condition expression
+//     keyCondition := expression.Key("foo").Equal(expression.Value("bar"))
+func Key(key string) KeyBuilder {
+	return KeyBuilder{
+		key: key,
+	}
+}
+
+// Plus creates a SetValueBuilder to be used in as an argument to Set(). The
+// arguments can either be NameBuilders or ValueBuilders. Plus() only supports
+// DynamoDB Number types, so the ValueBuilder must be a Number and the
+// NameBuilder must specify an item attribute of type Number.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.IncrementAndDecrement
+//
+// Example:
+//
+//     // Use Plus() to set the value of the item attribute "someName" to 5 + 10
+//     update, err := expression.Set(expression.Name("someName"), expression.Plus(expression.Value(5), expression.Value(10)))
+//
+// Expression Equivalent:
+//
+//     expression.Plus(expression.Value(5), expression.Value(10))
+//     // let :five and :ten be ExpressionAttributeValues for the values 5 and
+//     // 10 respectively.
+//     ":five + :ten"
+func Plus(leftOperand, rightOperand OperandBuilder) SetValueBuilder {
+	return SetValueBuilder{
+		leftOperand:  leftOperand,
+		rightOperand: rightOperand,
+		mode:         plusValueMode,
+	}
+}
+
+// Plus creates a SetValueBuilder to be used in as an argument to Set(). The
+// arguments can either be NameBuilders or ValueBuilders. Plus() only supports
+// DynamoDB Number types, so the ValueBuilder must be a Number and the
+// NameBuilder must specify an item attribute of type Number.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.IncrementAndDecrement
+//
+// Example:
+//
+//     // Use Plus() to set the value of the item attribute "someName" to the
+//     // numeric value of item attribute "aName" incremented by 10
+//     update, err := expression.Set(expression.Name("someName"), expression.Name("aName").Plus(expression.Value(10)))
+//
+// Expression Equivalent:
+//
+//     expression.Name("aName").Plus(expression.Value(10))
+//     // let :ten be ExpressionAttributeValues representing the value 10
+//     "aName + :ten"
+func (nb NameBuilder) Plus(rightOperand OperandBuilder) SetValueBuilder {
+	return Plus(nb, rightOperand)
+}
+
+// Plus creates a SetValueBuilder to be used in as an argument to Set(). The
+// arguments can either be NameBuilders or ValueBuilders. Plus() only supports
+// DynamoDB Number types, so the ValueBuilder must be a Number and the
+// NameBuilder must specify an item attribute of type Number.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.IncrementAndDecrement
+//
+// Example:
+//
+//     // Use Plus() to set the value of the item attribute "someName" to 5 + 10
+//     update, err := expression.Set(expression.Name("someName"), expression.Value(5).Plus(expression.Value(10)))
+//
+// Expression Equivalent:
+//
+//     expression.Value(5).Plus(expression.Value(10))
+//     // let :five and :ten be ExpressionAttributeValues representing the value
+//     // 5 and 10 respectively
+//     ":five + :ten"
+func (vb ValueBuilder) Plus(rightOperand OperandBuilder) SetValueBuilder {
+	return Plus(vb, rightOperand)
+}
+
+// Minus creates a SetValueBuilder to be used in as an argument to Set(). The
+// arguments can either be NameBuilders or ValueBuilders. Minus() only supports
+// DynamoDB Number types, so the ValueBuilder must be a Number and the
+// NameBuilder must specify an item attribute of type Number.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.IncrementAndDecrement
+//
+// Example:
+//
+//     // Use Minus() to set the value of item attribute "someName" to 5 - 10
+//     update, err := expression.Set(expression.Name("someName"), expression.Minus(expression.Value(5), expression.Value(10)))
+//
+// Expression Equivalent:
+//
+//     expression.Minus(expression.Value(5), expression.Value(10))
+//     // let :five and :ten be ExpressionAttributeValues for the values 5 and
+//     // 10 respectively.
+//     ":five - :ten"
+func Minus(leftOperand, rightOperand OperandBuilder) SetValueBuilder {
+	return SetValueBuilder{
+		leftOperand:  leftOperand,
+		rightOperand: rightOperand,
+		mode:         minusValueMode,
+	}
+}
+
+// Minus creates a SetValueBuilder to be used in as an argument to Set(). The
+// arguments can either be NameBuilders or ValueBuilders. Minus() only supports
+// DynamoDB Number types, so the ValueBuilder must be a Number and the
+// NameBuilder must specify an item attribute of type Number.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.IncrementAndDecrement
+//
+// Example:
+//
+//     // Use Minus() to set the value of item attribute "someName" to the
+//     // numeric value of "aName" decremented by 10
+//     update, err := expression.Set(expression.Name("someName"), expression.Name("aName").Minus(expression.Value(10)))
+//
+// Expression Equivalent:
+//
+//     expression.Name("aName").Minus(expression.Value(10)))
+//     // let :ten be ExpressionAttributeValues represent the value 10
+//     "aName - :ten"
+func (nb NameBuilder) Minus(rightOperand OperandBuilder) SetValueBuilder {
+	return Minus(nb, rightOperand)
+}
+
+// Minus creates a SetValueBuilder to be used in as an argument to Set(). The
+// arguments can either be NameBuilders or ValueBuilders. Minus() only supports
+// DynamoDB Number types, so the ValueBuilder must be a Number and the
+// NameBuilder must specify an item attribute of type Number.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.IncrementAndDecrement
+//
+// Example:
+//
+//     // Use Minus() to set the value of item attribute "someName" to 5 - 10
+//     update, err := expression.Set(expression.Name("someName"), expression.Value(5).Minus(expression.Value(10)))
+//
+// Expression Equivalent:
+//
+//     expression.Value(5).Minus(expression.Value(10))
+//     // let :five and :ten be ExpressionAttributeValues for the values 5 and
+//     // 10 respectively.
+//     ":five - :ten"
+func (vb ValueBuilder) Minus(rightOperand OperandBuilder) SetValueBuilder {
+	return Minus(vb, rightOperand)
+}
+
+// ListAppend creates a SetValueBuilder to be used in as an argument to Set().
+// The arguments can either be NameBuilders or ValueBuilders. ListAppend() only
+// supports DynamoDB List types, so the ValueBuilder must be a List and the
+// NameBuilder must specify an item attribute of type List.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.UpdatingListElements
+//
+// Example:
+//
+//     // Use ListAppend() to set item attribute "someName" to the item
+//     // attribute "nameOfList" with "some" and "list" appended to it
+//     update, err := expression.Set(expression.Name("someName"), expression.ListAppend(expression.Name("nameOfList"), expression.Value([]string{"some", "list"})))
+//
+// Expression Equivalent:
+//
+//     expression.ListAppend(expression.Name("nameOfList"), expression.Value([]string{"some", "list"})
+//     // let :list be a ExpressionAttributeValue representing the list
+//     // containing "some" and "list".
+//     "list_append (nameOfList, :list)"
+func ListAppend(leftOperand, rightOperand OperandBuilder) SetValueBuilder {
+	return SetValueBuilder{
+		leftOperand:  leftOperand,
+		rightOperand: rightOperand,
+		mode:         listAppendValueMode,
+	}
+}
+
+// ListAppend creates a SetValueBuilder to be used in as an argument to Set().
+// The arguments can either be NameBuilders or ValueBuilders. ListAppend() only
+// supports DynamoDB List types, so the ValueBuilder must be a List and the
+// NameBuilder must specify an item attribute of type List.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.UpdatingListElements
+//
+// Example:
+//
+//     // Use ListAppend() to set item attribute "someName" to the item
+//     // attribute "nameOfList" with "some" and "list" appended to it
+//     update, err := expression.Set(expression.Name("someName"), expression.Name("nameOfList").ListAppend(expression.Value([]string{"some", "list"})))
+//
+// Expression Equivalent:
+//
+//     expression.Name("nameOfList").ListAppend(expression.Value([]string{"some", "list"})
+//     // let :list be a ExpressionAttributeValue representing the list
+//     // containing "some" and "list".
+//     "list_append (nameOfList, :list)"
+func (nb NameBuilder) ListAppend(rightOperand OperandBuilder) SetValueBuilder {
+	return ListAppend(nb, rightOperand)
+}
+
+// ListAppend creates a SetValueBuilder to be used in as an argument to Set().
+// The arguments can either be NameBuilders or ValueBuilders. ListAppend() only
+// supports DynamoDB List types, so the ValueBuilder must be a List and the
+// NameBuilder must specify an item attribute of type List.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.UpdatingListElements
+//
+// Example:
+//
+//     // Use ListAppend() to set item attribute "someName" to a string list
+//     // equal to {"a", "list", "some", "list"}
+//     update, err := expression.Set(expression.Name("someName"), expression.Value([]string{"a", "list"}).ListAppend(expression.Value([]string{"some", "list"})))
+//
+// Expression Equivalent:
+//
+//     expression.Name([]string{"a", "list"}).ListAppend(expression.Value([]string{"some", "list"})
+//     // let :list1 and :list2 be a ExpressionAttributeValue representing the
+//     // list {"a", "list"} and {"some", "list"} respectively
+//     "list_append (:list1, :list2)"
+func (vb ValueBuilder) ListAppend(rightOperand OperandBuilder) SetValueBuilder {
+	return ListAppend(vb, rightOperand)
+}
+
+// IfNotExists creates a SetValueBuilder to be used in as an argument to Set().
+// The first argument must be a NameBuilder representing the name where the new
+// item attribute is created. The second argument can either be a NameBuilder or
+// a ValueBuilder. In the case that it is a NameBuilder, the value of the item
+// attribute at the name specified becomes the value of the new item attribute.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.PreventingAttributeOverwrites
+//
+// Example:
+//
+//     // Use IfNotExists() to set item attribute "someName" to value 5 if
+//     // "someName" does not exist yet. (Prevents overwrite)
+//     update, err := expression.Set(expression.Name("someName"), expression.IfNotExists(expression.Name("someName"), expression.Value(5)))
+//
+// Expression Equivalent:
+//
+//     expression.IfNotExists(expression.Name("someName"), expression.Value(5))
+//     // let :five be a ExpressionAttributeValue representing the value 5
+//     "if_not_exists (someName, :five)"
+func IfNotExists(name NameBuilder, setValue OperandBuilder) SetValueBuilder {
+	return SetValueBuilder{
+		leftOperand:  name,
+		rightOperand: setValue,
+		mode:         ifNotExistsValueMode,
+	}
+}
+
+// IfNotExists creates a SetValueBuilder to be used in as an argument to Set().
+// The first argument must be a NameBuilder representing the name where the new
+// item attribute is created. The second argument can either be a NameBuilder or
+// a ValueBuilder. In the case that it is a NameBuilder, the value of the item
+// attribute at the name specified becomes the value of the new item attribute.
+// More information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.PreventingAttributeOverwrites
+//
+// Example:
+//
+//     // Use IfNotExists() to set item attribute "someName" to value 5 if
+//     // "someName" does not exist yet. (Prevents overwrite)
+//     update, err := expression.Set(expression.Name("someName"), expression.Name("someName").IfNotExists(expression.Value(5)))
+//
+// Expression Equivalent:
+//
+//     expression.Name("someName").IfNotExists(expression.Value(5))
+//     // let :five be a ExpressionAttributeValue representing the value 5
+//     "if_not_exists (someName, :five)"
+func (nb NameBuilder) IfNotExists(rightOperand OperandBuilder) SetValueBuilder {
+	return IfNotExists(nb, rightOperand)
+}
+
+// BuildOperand creates an Operand struct which are building blocks to DynamoDB
+// Expressions. Package methods and functions can establish relationships
+// between operands, representing DynamoDB Expressions. The method
+// BuildOperand() is called recursively when the Build() method on the type
+// Builder is called. BuildOperand() should never be called externally.
+// BuildOperand() aliases all strings to avoid stepping over DynamoDB's reserved
+// words.
+// More information on reserved words at http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+func (nb NameBuilder) BuildOperand() (Operand, error) {
+	if nb.name == "" {
+		return Operand{}, newUnsetParameterError("BuildOperand", "NameBuilder")
+	}
+
+	node := exprNode{
+		names: []string{},
+	}
+
+	nameSplit := strings.Split(nb.name, ".")
+	fmtNames := make([]string, 0, len(nameSplit))
+
+	for _, word := range nameSplit {
+		var substr string
+		if word == "" {
+			return Operand{}, newInvalidParameterError("BuildOperand", "NameBuilder")
+		}
+
+		if word[len(word)-1] == ']' {
+			for j, char := range word {
+				if char == '[' {
+					substr = word[j:]
+					word = word[:j]
+					break
+				}
+			}
+		}
+
+		if word == "" {
+			return Operand{}, newInvalidParameterError("BuildOperand", "NameBuilder")
+		}
+
+		// Create a string with special characters that can be substituted later: $p
+		node.names = append(node.names, word)
+		fmtNames = append(fmtNames, "$n"+substr)
+	}
+	node.fmtExpr = strings.Join(fmtNames, ".")
+	return Operand{
+		exprNode: node,
+	}, nil
+}
+
+// BuildOperand creates an Operand struct which are building blocks to DynamoDB
+// Expressions. Package methods and functions can establish relationships
+// between operands, representing DynamoDB Expressions. The method
+// BuildOperand() is called recursively when the Build() method on the type
+// Builder is called. BuildOperand() should never be called externally.
+// BuildOperand() aliases all strings to avoid stepping over DynamoDB's reserved
+// words.
+// More information on reserved words at http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+func (vb ValueBuilder) BuildOperand() (Operand, error) {
+	expr, err := dynamodbattribute.Marshal(vb.value)
+	if err != nil {
+		return Operand{}, newInvalidParameterError("BuildOperand", "ValueBuilder")
+	}
+
+	// Create a string with special characters that can be substituted later: $v
+	operand := Operand{
+		exprNode: exprNode{
+			values:  []dynamodb.AttributeValue{*expr},
+			fmtExpr: "$v",
+		},
+	}
+	return operand, nil
+}
+
+// BuildOperand creates an Operand struct which are building blocks to DynamoDB
+// Expressions. Package methods and functions can establish relationships
+// between operands, representing DynamoDB Expressions. The method
+// BuildOperand() is called recursively when the Build() method on the type
+// Builder is called. BuildOperand() should never be called externally.
+// BuildOperand() aliases all strings to avoid stepping over DynamoDB's reserved
+// words.
+// More information on reserved words at http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+func (sb SizeBuilder) BuildOperand() (Operand, error) {
+	operand, err := sb.nameBuilder.BuildOperand()
+	operand.exprNode.fmtExpr = "size (" + operand.exprNode.fmtExpr + ")"
+
+	return operand, err
+}
+
+// BuildOperand creates an Operand struct which are building blocks to DynamoDB
+// Expressions. Package methods and functions can establish relationships
+// between operands, representing DynamoDB Expressions. The method
+// BuildOperand() is called recursively when the Build() method on the type
+// Builder is called. BuildOperand() should never be called externally.
+// BuildOperand() aliases all strings to avoid stepping over DynamoDB's reserved
+// words.
+// More information on reserved words at http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+func (kb KeyBuilder) BuildOperand() (Operand, error) {
+	if kb.key == "" {
+		return Operand{}, newUnsetParameterError("BuildOperand", "KeyBuilder")
+	}
+
+	ret := Operand{
+		exprNode: exprNode{
+			names:   []string{kb.key},
+			fmtExpr: "$n",
+		},
+	}
+
+	return ret, nil
+}
+
+// BuildOperand creates an Operand struct which are building blocks to DynamoDB
+// Expressions. Package methods and functions can establish relationships
+// between operands, representing DynamoDB Expressions. The method
+// BuildOperand() is called recursively when the Build() method on the type
+// Builder is called. BuildOperand() should never be called externally.
+// BuildOperand() aliases all strings to avoid stepping over DynamoDB's reserved
+// words.
+// More information on reserved words at http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+func (svb SetValueBuilder) BuildOperand() (Operand, error) {
+	if svb.mode == unsetValue {
+		return Operand{}, newUnsetParameterError("BuildOperand", "SetValueBuilder")
+	}
+
+	left, err := svb.leftOperand.BuildOperand()
+	if err != nil {
+		return Operand{}, err
+	}
+	leftNode := left.exprNode
+
+	right, err := svb.rightOperand.BuildOperand()
+	if err != nil {
+		return Operand{}, err
+	}
+	rightNode := right.exprNode
+
+	node := exprNode{
+		children: []exprNode{leftNode, rightNode},
+	}
+
+	switch svb.mode {
+	case plusValueMode:
+		node.fmtExpr = "$c + $c"
+	case minusValueMode:
+		node.fmtExpr = "$c - $c"
+	case listAppendValueMode:
+		node.fmtExpr = "list_append($c, $c)"
+	case ifNotExistsValueMode:
+		node.fmtExpr = "if_not_exists($c, $c)"
+	default:
+		return Operand{}, fmt.Errorf("build operand error: unsupported mode: %v", svb.mode)
+	}
+
+	return Operand{
+		exprNode: node,
+	}, nil
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/projection.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/projection.go
@@ -1,0 +1,148 @@
+package expression
+
+import (
+	"strings"
+)
+
+// ProjectionBuilder represents Projection Expressions in DynamoDB.
+// ProjectionBuilders are the building blocks of Builders.
+// More Information at: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ProjectionExpressions.html
+type ProjectionBuilder struct {
+	names []NameBuilder
+}
+
+// NamesList returns a ProjectionBuilder representing the list of item
+// attribute names specified by the argument NameBuilders. The resulting
+// ProjectionBuilder can be used as a part of other ProjectionBuilders or as an
+// argument to the WithProjection() method for the Builder struct.
+//
+// Example:
+//
+//     // projection represents the list of names {"foo", "bar"}
+//     projection := expression.NamesList(expression.Name("foo"), expression.Name("bar"))
+//
+//     // Used in another Projection Expression
+//     anotherProjection := expression.AddNames(projection, expression.Name("baz"))
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithProjection(newProjection)
+//
+// Expression Equivalent:
+//
+//     expression.NamesList(expression.Name("foo"), expression.Name("bar"))
+//     "foo, bar"
+func NamesList(nameBuilder NameBuilder, namesList ...NameBuilder) ProjectionBuilder {
+	namesList = append([]NameBuilder{nameBuilder}, namesList...)
+	return ProjectionBuilder{
+		names: namesList,
+	}
+}
+
+// NamesList returns a ProjectionBuilder representing the list of item
+// attribute names specified by the argument NameBuilders. The resulting
+// ProjectionBuilder can be used as a part of other ProjectionBuilders or as an
+// argument to the WithProjection() method for the Builder struct.
+//
+// Example:
+//
+//     // projection represents the list of names {"foo", "bar"}
+//     projection := expression.Name("foo").NamesList(expression.Name("bar"))
+//
+//     // Used in another Projection Expression
+//     anotherProjection := expression.AddNames(projection, expression.Name("baz"))
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithProjection(newProjection)
+//
+// Expression Equivalent:
+//
+//     expression.Name("foo").NamesList(expression.Name("bar"))
+//     "foo, bar"
+func (nb NameBuilder) NamesList(namesList ...NameBuilder) ProjectionBuilder {
+	return NamesList(nb, namesList...)
+}
+
+// AddNames returns a ProjectionBuilder representing the list of item
+// attribute names equivalent to appending all of the argument item attribute
+// names to the argument ProjectionBuilder. The resulting ProjectionBuilder can
+// be used as a part of other ProjectionBuilders or as an argument to the
+// WithProjection() method for the Builder struct.
+//
+// Example:
+//
+//     // projection represents the list of names {"foo", "bar", "baz", "qux"}
+//     oldProj := expression.NamesList(expression.Name("foo"), expression.Name("bar"))
+//     projection := expression.AddNames(oldProj, expression.Name("baz"), expression.Name("qux"))
+//
+//     // Used in another Projection Expression
+//     anotherProjection := expression.AddNames(projection, expression.Name("quux"))
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithProjection(newProjection)
+//
+// Expression Equivalent:
+//
+//     expression.AddNames(expression.NamesList(expression.Name("foo"), expression.Name("bar")), expression.Name("baz"), expression.Name("qux"))
+//     "foo, bar, baz, qux"
+func AddNames(projectionBuilder ProjectionBuilder, namesList ...NameBuilder) ProjectionBuilder {
+	projectionBuilder.names = append(projectionBuilder.names, namesList...)
+	return projectionBuilder
+}
+
+// AddNames returns a ProjectionBuilder representing the list of item
+// attribute names equivalent to appending all of the argument item attribute
+// names to the argument ProjectionBuilder. The resulting ProjectionBuilder can
+// be used as a part of other ProjectionBuilders or as an argument to the
+// WithProjection() method for the Builder struct.
+//
+// Example:
+//
+//     // projection represents the list of names {"foo", "bar", "baz", "qux"}
+//     oldProj := expression.NamesList(expression.Name("foo"), expression.Name("bar"))
+//     projection := oldProj.AddNames(expression.Name("baz"), expression.Name("qux"))
+//
+//     // Used in another Projection Expression
+//     anotherProjection := expression.AddNames(projection, expression.Name("quux"))
+//     // Used to make an Builder
+//     builder := expression.NewBuilder().WithProjection(newProjection)
+//
+// Expression Equivalent:
+//
+//     expression.NamesList(expression.Name("foo"), expression.Name("bar")).AddNames(expression.Name("baz"), expression.Name("qux"))
+//     "foo, bar, baz, qux"
+func (pb ProjectionBuilder) AddNames(namesList ...NameBuilder) ProjectionBuilder {
+	return AddNames(pb, namesList...)
+}
+
+// buildTree builds a tree structure of exprNodes based on the tree
+// structure of the input ProjectionBuilder's child NameBuilders. buildTree()
+// satisfies the treeBuilder interface so ProjectionBuilder can be a part of
+// Builder and Expression struct.
+func (pb ProjectionBuilder) buildTree() (exprNode, error) {
+	if len(pb.names) == 0 {
+		return exprNode{}, newUnsetParameterError("buildTree", "ProjectionBuilder")
+	}
+
+	childNodes, err := pb.buildChildNodes()
+	if err != nil {
+		return exprNode{}, err
+	}
+	ret := exprNode{
+		children: childNodes,
+	}
+
+	ret.fmtExpr = "$c" + strings.Repeat(", $c", len(pb.names)-1)
+
+	return ret, nil
+}
+
+// buildChildNodes creates the list of the child exprNodes.
+func (pb ProjectionBuilder) buildChildNodes() ([]exprNode, error) {
+	childNodes := make([]exprNode, 0, len(pb.names))
+	for _, name := range pb.names {
+		operand, err := name.BuildOperand()
+		if err != nil {
+			return []exprNode{}, err
+		}
+		childNodes = append(childNodes, operand.exprNode)
+	}
+
+	return childNodes, nil
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/update.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/expression/update.go
@@ -1,0 +1,391 @@
+package expression
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// operationMode specifies the types of update operations that the
+// updateBuilder is going to represent. The const is in a string to use the
+// const value as a map key and as a string when creating the formatted
+// expression for the exprNodes.
+type operationMode string
+
+const (
+	setOperation    operationMode = "SET"
+	removeOperation               = "REMOVE"
+	addOperation                  = "ADD"
+	deleteOperation               = "DELETE"
+)
+
+// Implementing the Sort interface
+type modeList []operationMode
+
+func (ml modeList) Len() int {
+	return len(ml)
+}
+
+func (ml modeList) Less(i, j int) bool {
+	return string(ml[i]) < string(ml[j])
+}
+
+func (ml modeList) Swap(i, j int) {
+	ml[i], ml[j] = ml[j], ml[i]
+}
+
+// UpdateBuilder represents Update Expressions in DynamoDB. UpdateBuilders
+// are the building blocks of the Builder struct. Note that there are different
+// update operations in DynamoDB and an UpdateBuilder can represent multiple
+// update operations.
+// More Information at: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html
+type UpdateBuilder struct {
+	operationList map[operationMode][]operationBuilder
+}
+
+// operationBuilder represents specific update actions (SET, REMOVE, ADD,
+// DELETE). The mode specifies what type of update action the
+// operationBuilder represents.
+type operationBuilder struct {
+	name  NameBuilder
+	value OperandBuilder
+	mode  operationMode
+}
+
+// buildOperation builds an exprNode from an operationBuilder. buildOperation
+// is called recursively by buildTree in order to create a tree structure
+// of exprNodes representing the parent/child relationships between
+// UpdateBuilders and operationBuilders.
+func (ob operationBuilder) buildOperation() (exprNode, error) {
+	pathChild, err := ob.name.BuildOperand()
+	if err != nil {
+		return exprNode{}, err
+	}
+
+	node := exprNode{
+		children: []exprNode{pathChild.exprNode},
+		fmtExpr:  "$c",
+	}
+
+	if ob.mode == removeOperation {
+		return node, nil
+	}
+
+	valueChild, err := ob.value.BuildOperand()
+	if err != nil {
+		return exprNode{}, err
+	}
+	node.children = append(node.children, valueChild.exprNode)
+
+	switch ob.mode {
+	case setOperation:
+		node.fmtExpr += " = $c"
+	case addOperation, deleteOperation:
+		node.fmtExpr += " $c"
+	default:
+		return exprNode{}, fmt.Errorf("build update error: build operation error: unsupported mode: %v", ob.mode)
+	}
+
+	return node, nil
+}
+
+// Delete returns an UpdateBuilder representing one Delete operation for
+// DynamoDB Update Expressions. The argument name should specify the item
+// attribute and the argument value should specify the value to be deleted. The
+// resulting UpdateBuilder can be used as an argument to the WithUpdate() method
+// for the Builder struct.
+//
+// Example:
+//
+//     // update represents the delete operation to delete the string value
+//     // "subsetToDelete" from the item attribute "pathToList"
+//     update := expression.Delete(expression.Name("pathToList"), expression.Value("subsetToDelete"))
+//
+//     // Adding more update methods
+//     anotherUpdate := update.Remove(expression.Name("someName"))
+//     // Creating a Builder
+//     builder := Update(update)
+//
+// Expression Equivalent:
+//
+//     expression.Delete(expression.Name("pathToList"), expression.Value("subsetToDelete"))
+//     // let :del be an ExpressionAttributeValue representing the value
+//     // "subsetToDelete"
+//     "DELETE pathToList :del"
+func Delete(name NameBuilder, value ValueBuilder) UpdateBuilder {
+	emptyUpdateBuilder := UpdateBuilder{}
+	return emptyUpdateBuilder.Delete(name, value)
+}
+
+// Delete adds a Delete operation to the argument UpdateBuilder. The
+// argument name should specify the item attribute and the argument value should
+// specify the value to be deleted. The resulting UpdateBuilder can be used as
+// an argument to the WithUpdate() method for the Builder struct.
+//
+// Example:
+//
+//     // Let update represent an already existing update expression. Delete()
+//     // adds the operation to delete the value "subsetToDelete" from the item
+//     // attribute "pathToList"
+//     update := update.Delete(expression.Name("pathToList"), expression.Value("subsetToDelete"))
+//
+//     // Adding more update methods
+//     anotherUpdate := update.Remove(expression.Name("someName"))
+//     // Creating a Builder
+//     builder := Update(update)
+//
+// Expression Equivalent:
+//
+//     Delete(expression.Name("pathToList"), expression.Value("subsetToDelete"))
+//     // let :del be an ExpressionAttributeValue representing the value
+//     // "subsetToDelete"
+//     "DELETE pathToList :del"
+func (ub UpdateBuilder) Delete(name NameBuilder, value ValueBuilder) UpdateBuilder {
+	if ub.operationList == nil {
+		ub.operationList = map[operationMode][]operationBuilder{}
+	}
+	ub.operationList[deleteOperation] = append(ub.operationList[deleteOperation], operationBuilder{
+		name:  name,
+		value: value,
+		mode:  deleteOperation,
+	})
+	return ub
+}
+
+// Add returns an UpdateBuilder representing the Add operation for DynamoDB
+// Update Expressions. The argument name should specify the item attribute and
+// the argument value should specify the value to be added. The resulting
+// UpdateBuilder can be used as an argument to the WithUpdate() method for the
+// Builder struct.
+//
+// Example:
+//
+//     // update represents the add operation to add the value 5 to the item
+//     // attribute "aPath"
+//     update := expression.Add(expression.Name("aPath"), expression.Value(5))
+//
+//     // Adding more update methods
+//     anotherUpdate := update.Remove(expression.Name("someName"))
+//     // Creating a Builder
+//     builder := Update(update)
+//
+// Expression Equivalent:
+//
+//     expression.Add(expression.Name("aPath"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "ADD aPath :5"
+func Add(name NameBuilder, value ValueBuilder) UpdateBuilder {
+	emptyUpdateBuilder := UpdateBuilder{}
+	return emptyUpdateBuilder.Add(name, value)
+}
+
+// Add adds an Add operation to the argument UpdateBuilder. The argument
+// name should specify the item attribute and the argument value should specify
+// the value to be added. The resulting UpdateBuilder can be used as an argument
+// to the WithUpdate() method for the Builder struct.
+//
+// Example:
+//
+//     // Let update represent an already existing update expression. Add() adds
+//     // the operation to add the value 5 to the item attribute "aPath"
+//     update := update.Add(expression.Name("aPath"), expression.Value(5))
+//
+//     // Adding more update methods
+//     anotherUpdate := update.Remove(expression.Name("someName"))
+//     // Creating a Builder
+//     builder := Update(update)
+//
+// Expression Equivalent:
+//
+//     Add(expression.Name("aPath"), expression.Value(5))
+//     // Let :five be an ExpressionAttributeValue representing the value 5
+//     "ADD aPath :5"
+func (ub UpdateBuilder) Add(name NameBuilder, value ValueBuilder) UpdateBuilder {
+	if ub.operationList == nil {
+		ub.operationList = map[operationMode][]operationBuilder{}
+	}
+	ub.operationList[addOperation] = append(ub.operationList[addOperation], operationBuilder{
+		name:  name,
+		value: value,
+		mode:  addOperation,
+	})
+	return ub
+}
+
+// Remove returns an UpdateBuilder representing the Remove operation for
+// DynamoDB Update Expressions. The argument name should specify the item
+// attribute to delete. The resulting UpdateBuilder can be used as an argument
+// to the WithUpdate() method for the Builder struct.
+//
+// Example:
+//
+//     // update represents the remove operation to remove the item attribute
+//     // "itemToRemove"
+//     update := expression.Remove(expression.Name("itemToRemove"))
+//
+//     // Adding more update methods
+//     anotherUpdate := update.Remove(expression.Name("someName"))
+//     // Creating a Builder
+//     builder := Update(update)
+//
+// Expression Equivalent:
+//
+//     expression.Remove(expression.Name("itemToRemove"))
+//     "REMOVE itemToRemove"
+func Remove(name NameBuilder) UpdateBuilder {
+	emptyUpdateBuilder := UpdateBuilder{}
+	return emptyUpdateBuilder.Remove(name)
+}
+
+// Remove adds a Remove operation to the argument UpdateBuilder. The
+// argument name should specify the item attribute to delete. The resulting
+// UpdateBuilder can be used as an argument to the WithUpdate() method for the
+// Builder struct.
+//
+// Example:
+//
+//     // Let update represent an already existing update expression. Remove()
+//     // adds the operation to remove the item attribute "itemToRemove"
+//     update := update.Remove(expression.Name("itemToRemove"))
+//
+//     // Adding more update methods
+//     anotherUpdate := update.Remove(expression.Name("someName"))
+//     // Creating a Builder
+//     builder := Update(update)
+//
+// Expression Equivalent:
+//
+//     Remove(expression.Name("itemToRemove"))
+//     "REMOVE itemToRemove"
+func (ub UpdateBuilder) Remove(name NameBuilder) UpdateBuilder {
+	if ub.operationList == nil {
+		ub.operationList = map[operationMode][]operationBuilder{}
+	}
+	ub.operationList[removeOperation] = append(ub.operationList[removeOperation], operationBuilder{
+		name: name,
+		mode: removeOperation,
+	})
+	return ub
+}
+
+// Set returns an UpdateBuilder representing the Set operation for DynamoDB
+// Update Expressions. The argument name should specify the item attribute to
+// modify. The argument OperandBuilder should specify the value to modify the
+// the item attribute to. The resulting UpdateBuilder can be used as an argument
+// to the WithUpdate() method for the Builder struct.
+//
+// Example:
+//
+//     // update represents the set operation to set the item attribute
+//     // "itemToSet" to the value "setValue" if the item attribute does not
+//     // exist yet. (conditional write)
+//     update := expression.Set(expression.Name("itemToSet"), expression.IfNotExists(expression.Name("itemToSet"), expression.Value("setValue")))
+//
+//     // Adding more update methods
+//     anotherUpdate := update.Remove(expression.Name("someName"))
+//     // Creating a Builder
+//     builder := Update(update)
+//
+// Expression Equivalent:
+//
+//     expression.Set(expression.Name("itemToSet"), expression.IfNotExists(expression.Name("itemToSet"), expression.Value("setValue")))
+//     // Let :val be an ExpressionAttributeValue representing the value
+//     // "setValue"
+//     "SET itemToSet = :val"
+func Set(name NameBuilder, operandBuilder OperandBuilder) UpdateBuilder {
+	emptyUpdateBuilder := UpdateBuilder{}
+	return emptyUpdateBuilder.Set(name, operandBuilder)
+}
+
+// Set adds a Set operation to the argument UpdateBuilder. The argument name
+// should specify the item attribute to modify. The argument OperandBuilder
+// should specify the value to modify the the item attribute to. The resulting
+// UpdateBuilder can be used as an argument to the WithUpdate() method for the
+// Builder struct.
+//
+// Example:
+//
+//     // Let update represent an already existing update expression. Set() adds
+//     // the operation to to set the item attribute "itemToSet" to the value
+//     // "setValue" if the item attribute does not exist yet. (conditional
+//     // write)
+//     update := update.Set(expression.Name("itemToSet"), expression.IfNotExists(expression.Name("itemToSet"), expression.Value("setValue")))
+//
+//     // Adding more update methods
+//     anotherUpdate := update.Remove(expression.Name("someName"))
+//     // Creating a Builder
+//     builder := Update(update)
+//
+// Expression Equivalent:
+//
+//     Set(expression.Name("itemToSet"), expression.IfNotExists(expression.Name("itemToSet"), expression.Value("setValue")))
+//     // Let :val be an ExpressionAttributeValue representing the value
+//     // "setValue"
+//     "SET itemToSet = :val"
+func (ub UpdateBuilder) Set(name NameBuilder, operandBuilder OperandBuilder) UpdateBuilder {
+	if ub.operationList == nil {
+		ub.operationList = map[operationMode][]operationBuilder{}
+	}
+	ub.operationList[setOperation] = append(ub.operationList[setOperation], operationBuilder{
+		name:  name,
+		value: operandBuilder,
+		mode:  setOperation,
+	})
+	return ub
+}
+
+// buildTree builds a tree structure of exprNodes based on the tree
+// structure of the input UpdateBuilder's child UpdateBuilders/Operands.
+// buildTree() satisfies the TreeBuilder interface so ProjectionBuilder can be a
+// part of Expression struct.
+func (ub UpdateBuilder) buildTree() (exprNode, error) {
+	if ub.operationList == nil {
+		return exprNode{}, newUnsetParameterError("buildTree", "UpdateBuilder")
+	}
+	ret := exprNode{
+		children: []exprNode{},
+	}
+
+	modes := modeList{}
+
+	for mode := range ub.operationList {
+		modes = append(modes, mode)
+	}
+
+	sort.Sort(modes)
+
+	for _, key := range modes {
+		ret.fmtExpr += string(key) + " $c\n"
+
+		childNode, err := buildChildNodes(ub.operationList[key])
+		if err != nil {
+			return exprNode{}, err
+		}
+
+		ret.children = append(ret.children, childNode)
+	}
+
+	return ret, nil
+}
+
+// buildChildNodes creates the list of the child exprNodes.
+func buildChildNodes(operationBuilderList []operationBuilder) (exprNode, error) {
+	if len(operationBuilderList) == 0 {
+		return exprNode{}, fmt.Errorf("buildChildNodes error: operationBuilder list is empty")
+	}
+
+	node := exprNode{
+		children: make([]exprNode, 0, len(operationBuilderList)),
+		fmtExpr:  "$c" + strings.Repeat(", $c", len(operationBuilderList)-1),
+	}
+
+	for _, val := range operationBuilderList {
+		valNode, err := val.buildOperation()
+		if err != nil {
+			return exprNode{}, err
+		}
+		node.children = append(node.children, valNode)
+	}
+
+	return node, nil
+}


### PR DESCRIPTION
## Overview

Refactors the `Deprovision` and `LastOperation` APIs. Now, after a successful deprovision (i.e. when the stack status is `DELETE_COMPLETE`), `LastOperation` attempts to delete the service instance item from the metadata table.

## Related Issues

Resolves #44.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
