### PR TITLE
resolves #49, as takes unencoded data from the user

### DIFF
--- a/packaging/openshift/deploy.sh
+++ b/packaging/openshift/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-ACCESSKEYID=$1
-SECRETKEY=$2
+ACCESSKEYID=$(echo -n $1 | base64)
+SECRETKEY=$(echo -n $2 | base64)
 oc new-project aws-sb
 CA=`oc get secret -n kube-service-catalog -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{ index .data "service-ca.crt" }}{{end}}{{"\n"}}{{end}}' | grep -v '^$' | tail -n 1`
 oc process -f aws-servicebroker.yaml --param-file=parameters.env -p BROKER_CA_CERT=$CA -p ACCESSKEYID=${ACCESSKEYID} -p SECRETKEY=${SECRETKEY} | oc apply -f -


### PR DESCRIPTION
## Overview

This should resolve issues with #49 as it encodes a user's secrets when it creates them in OpenShift. 

## Related Issues

Fixes #49 

## Testing

This was the modification I made to the script in order to fix the issues I had run into during a deployment. It corrects the manual changes one has to make if you don't have such a commit. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
