### PR TITLE
[dynamodb] Use HashAttributeType and RangeAttributeType

### DIFF
--- a/templates/dynamodb/template.yaml
+++ b/templates/dynamodb/template.yaml
@@ -116,10 +116,10 @@ Resources:
       AttributeDefinitions:
         -
           AttributeName: !Ref HashAttributeName
-          AttributeType: "S"
+          AttributeType: !Ref HashAttributeType
         -
           AttributeName: !Ref RangeAttributeName
-          AttributeType: "S"
+          AttributeType: !Ref RangeAttributeType
       ProvisionedThroughput:
         ReadCapacityUnits: !Ref ReadCapacityUnits
         WriteCapacityUnits: !Ref WriteCapacityUnits


### PR DESCRIPTION
## Overview

Updates the `dynamodb` template to use `HashAttributeType` and `RangeAttributeType` instead of hardcoding the data types to `S`.

## Related Issues

Fixes #58.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
