### PR TITLE
Allow overriding with an empty string

### DIFF
--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -83,10 +83,8 @@ func getOverridesFromEnv() map[string]string {
 		envvar := strings.Split(item, "=")
 		if strings.HasPrefix(envvar[0], "PARAM_OVERRIDE_") {
 			key := strings.TrimPrefix(envvar[0], "PARAM_OVERRIDE_")
-			if envvar[1] != "" {
-				Overrides[key] = envvar[1]
-				glog.V(10).Infof("%q=%q\n", key, envvar[1])
-			}
+			Overrides[key] = envvar[1]
+			glog.V(10).Infof("%q=%q\n", key, envvar[1])
 		}
 	}
 	return Overrides


### PR DESCRIPTION
## Overview

Allows a parameter override to be set to `""`.

## Related Issues

Fixes #60.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
