### PR TITLE
Remove check for no updatable parameters

### DIFF
--- a/pkg/broker/api.go
+++ b/pkg/broker/api.go
@@ -436,37 +436,34 @@ func (b *AwsBroker) Update(request *osb.UpdateInstanceRequest, c *broker.Request
 	// Get the service instance
 	instance, err := b.db.DataStorePort.GetServiceInstance(request.InstanceID)
 	if err != nil {
-		desc := fmt.Sprintf("Failed to get the service instance %s: %v", request.InstanceID, err)
+		desc := fmt.Sprintf("Failed to get the service instance %q: %v", request.InstanceID, err)
 		return nil, newHTTPStatusCodeError(http.StatusInternalServerError, "", desc)
 	} else if instance == nil {
-		desc := fmt.Sprintf("The service instance %s was not found.", request.InstanceID)
+		desc := fmt.Sprintf("The service instance %q was not found.", request.InstanceID)
 		return nil, newHTTPStatusCodeError(http.StatusBadRequest, "", desc)
 	}
 
 	// Verify that we're not changing the plan (this should never happen since
 	// we're setting `plan_updateable: false`, but better safe than sorry)
 	if request.PlanID != nil && *request.PlanID != instance.PlanID {
-		desc := fmt.Sprintf("The service plan cannot be changed from %s to %s.", instance.PlanID, *request.PlanID)
+		desc := fmt.Sprintf("The service plan cannot be changed from %q to %q.", instance.PlanID, *request.PlanID)
 		return nil, newHTTPStatusCodeError(http.StatusBadRequest, "", desc)
 	}
 
 	// Get the service
 	service, err := b.db.DataStorePort.GetServiceDefinition(request.ServiceID)
 	if err != nil {
-		desc := fmt.Sprintf("Failed to get the service %s: %v", request.ServiceID, err)
+		desc := fmt.Sprintf("Failed to get the service %q: %v", request.ServiceID, err)
 		return nil, newHTTPStatusCodeError(http.StatusInternalServerError, "", desc)
 	} else if service == nil {
-		desc := fmt.Sprintf("The service %s was not found.", request.ServiceID)
+		desc := fmt.Sprintf("The service %q was not found.", request.ServiceID)
 		return nil, newHTTPStatusCodeError(http.StatusBadRequest, "", desc)
 	}
 
-	// Get the plan and verify that it has updatable parameters
+	// Get the plan
 	plan := getPlan(service, instance.PlanID)
 	if plan == nil {
-		desc := fmt.Sprintf("The service plan %s was not found.", instance.PlanID)
-		return nil, newHTTPStatusCodeError(http.StatusBadRequest, "", desc)
-	} else if plan.Schemas.ServiceInstance.Update == nil {
-		desc := fmt.Sprintf("The service plan %s has no updatable parameters.", instance.PlanID)
+		desc := fmt.Sprintf("The service plan %q was not found.", instance.PlanID)
 		return nil, newHTTPStatusCodeError(http.StatusBadRequest, "", desc)
 	}
 
@@ -481,7 +478,7 @@ func (b *AwsBroker) Update(request *osb.UpdateInstanceRequest, c *broker.Request
 		newValue := paramValue(v)
 		if params[k] != newValue {
 			if !stringInSlice(k, updatableParams) {
-				desc := fmt.Sprintf("The parameter %s is not updatable.", k)
+				desc := fmt.Sprintf("The parameter %q is not updatable.", k)
 				return nil, newHTTPStatusCodeError(http.StatusBadRequest, "", desc)
 			}
 			params[k] = newValue
@@ -503,7 +500,7 @@ func (b *AwsBroker) Update(request *osb.UpdateInstanceRequest, c *broker.Request
 		TemplateURL:  b.generateS3HTTPUrl(service.Name),
 	})
 	if err != nil {
-		desc := fmt.Sprintf("Failed to update the CloudFormation stack %s: %v", instance.StackID, err)
+		desc := fmt.Sprintf("Failed to update the CloudFormation stack %q: %v", instance.StackID, err)
 		return nil, newHTTPStatusCodeError(http.StatusInternalServerError, "", desc)
 	}
 
@@ -513,11 +510,11 @@ func (b *AwsBroker) Update(request *osb.UpdateInstanceRequest, c *broker.Request
 	if err != nil {
 		// Try to cancel the update
 		if _, err := cfnSvc.Client.CancelUpdateStack(&cloudformation.CancelUpdateStackInput{StackName: aws.String(instance.StackID)}); err != nil {
-			glog.Errorf("Failed to cancel updating the CloudFormation stack %s: %v", instance.StackID, err)
-			glog.Errorf("Service instance %s and CloudFormation stack %s may be out of sync!", instance.ID, instance.StackID)
+			glog.Errorf("Failed to cancel updating the CloudFormation stack %q: %v", instance.StackID, err)
+			glog.Errorf("Service instance %q and CloudFormation stack %q may be out of sync!", instance.ID, instance.StackID)
 		}
 
-		desc := fmt.Sprintf("Failed to update the service instance %s: %v", instance.ID, err)
+		desc := fmt.Sprintf("Failed to update the service instance %q: %v", instance.ID, err)
 		return nil, newHTTPStatusCodeError(http.StatusInternalServerError, "", desc)
 	}
 

--- a/pkg/broker/awsbroker_test.go
+++ b/pkg/broker/awsbroker_test.go
@@ -308,6 +308,7 @@ type mockCfn struct {
 	DescribeStacksResponse cloudformation.DescribeStacksOutput
 	CreateStackResponse    cloudformation.CreateStackOutput
 	DeleteStackResponse    cloudformation.DeleteStackOutput
+	UpdateStackResponse    cloudformation.UpdateStackOutput
 }
 
 func (m mockCfn) DescribeStacks(in *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
@@ -326,6 +327,17 @@ func (m mockCfn) DeleteStack(in *cloudformation.DeleteStackInput) (*cloudformati
 		return nil, errors.New("test failure")
 	}
 	return &m.DeleteStackResponse, nil
+}
+
+func (m mockCfn) UpdateStack(in *cloudformation.UpdateStackInput) (*cloudformation.UpdateStackOutput, error) {
+	if aws.StringValue(in.StackName) == "err" {
+		return nil, errors.New("test failure")
+	}
+	return &m.UpdateStackResponse, nil
+}
+
+func (m mockCfn) CancelUpdateStack(in *cloudformation.CancelUpdateStackInput) (*cloudformation.CancelUpdateStackOutput, error) {
+	return &cloudformation.CancelUpdateStackOutput{}, nil
 }
 
 func TestMetadataUpdate(t *testing.T) {

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -320,10 +320,12 @@ func getAvailableParams(plan *osb.Plan) (params []string) {
 }
 
 func getUpdatableParams(plan *osb.Plan) (params []string) {
-	properties := plan.Schemas.ServiceInstance.Update.Parameters.(map[string]interface{})["properties"]
-	if properties != nil {
-		for k := range properties.(map[string]interface{}) {
-			params = append(params, k)
+	if plan.Schemas.ServiceInstance.Update != nil {
+		properties := plan.Schemas.ServiceInstance.Update.Parameters.(map[string]interface{})["properties"]
+		if properties != nil {
+			for k := range properties.(map[string]interface{}) {
+				params = append(params, k)
+			}
 		}
 	}
 	return


### PR DESCRIPTION
## Overview

If an attempt is made to update an instance with no updatable parameters, the update will fail and the instance will be left in status `Failed`. This change allows the instance to be updated back to its original parameters to get its status back to `Ready`.

This also adds tests for `Update`, increasing coverage from 0% to 96.4%.

## Related Issues

Fixes #54.

(We should create a new issue if the `rds` class needs some updatable parameters.)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
