### PR TITLE
Update install_prereqs.md

### DIFF
--- a/docs/install_prereqs.md
+++ b/docs/install_prereqs.md
@@ -39,7 +39,8 @@ The user or role that the broker runs as requires the following policy:
     {
       "Action": [
         "dynamodb:PutItem",
-        "dynamodb:GetItem"
+        "dynamodb:GetItem",
+        "dynamodb:DeleteItem"
       ],
       "Resource": "arn:aws:dynamodb:<REGION>:<ACCOUNT_ID>:table/<TABLE_NAME>",
       "Effect": "Allow"


### PR DESCRIPTION
## Overview

Deleting a service instance threw permissions errors because it was unable to call DeleteItem.

After adding this permission it no longer threw errors.

## Testing

I've tried it on a test cluster.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
