### PR TITLE
Make cluster domain configurable

### DIFF
--- a/packaging/helm/aws-servicebroker/templates/broker.yaml
+++ b/packaging/helm/aws-servicebroker/templates/broker.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  url: https://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  url: https://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   insecureSkipTLSVerify: true
 {{- if .Values.authenticate}}
   authInfo:

--- a/packaging/helm/aws-servicebroker/values.yaml
+++ b/packaging/helm/aws-servicebroker/values.yaml
@@ -21,3 +21,4 @@ brokerconfig:
   brokerid: awsservicebroker
   prescribeoverrides: true
 annotations: {}
+clusterDomain: cluster.local


### PR DESCRIPTION
- cluster.local is the default domain.  Some clusters may change this
value.

Signed-off-by: Dan Wendorf <dan.wendorf@opendoor.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/awslabs/aws-servicebroker/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, add "[WIP]" to the beginning of the PR title
-->

## Overview

Brief description of what this PR does, and why it is needed (use case)?

Our Kubernetes cluster uses a non default cluster domain and would like to use this chart to install the aws service broker

## Related Issues

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

## Testing

How did you validate the changes in this PR? If there are unit tests included describe what they test

Ran `helm install`

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output

Run `helm template --set clusterDomain=my.local.domain`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
