### PR TITLE
Add `OutputsAsIs` optional field to metadata for a service

### DIFF
--- a/pkg/broker/awsbroker.go
+++ b/pkg/broker/awsbroker.go
@@ -232,6 +232,7 @@ func (db Db) ServiceDefinitionToOsb(sd CfnTemplate) osb.Service {
 			"documentationUrl":    sd.Metadata.Spec.DocumentationUrl,
 			"imageUrl":            sd.Metadata.Spec.ImageUrl,
 			"longDescription":     sd.Metadata.Spec.LongDescription,
+			"outputsAsIs":         sd.Metadata.Spec.OutputsAsIs,
 		},
 		PlanUpdatable: aws.Bool(false),
 	}

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -162,6 +162,7 @@ type CfnTemplate struct {
 			ImageUrl            string   `yaml:"ImageUrl,omitempty"`
 			DocumentationUrl    string   `yaml:"DocumentationUrl,omitempty"`
 			ProviderDisplayName string   `yaml:"ProviderDisplayName,omitempty"`
+			OutputsAsIs         bool     `yaml:"OutputsAsIs,omitempty"`
 			Bindings            struct {
 				IAM struct {
 					AddKeypair bool `yaml:"AddKeypair,omitempty"`


### PR DESCRIPTION
When set to `True`, output keys from CloudFormation are not converted to
screaming snake case before added to service bindings.

This is useful when needing to be compatible with existing libraries.

## Overview

Many existing libraries assume certain names for parameters in service bindings, e.g. the CloudFoundry Spring Connectors for Redis look for `Uri` and `Url`.

Currently the broker always converts the names in the CloudFormation template to `SCREAMING_SNAKE_CASE` (my life is enriched from now knowing this term).

This PR allows some service metadata to specify that this should not happen. If not specified, the current behaviour will continue.

## Related Issues

Fixes #78

## Testing

Read, built, ran, tested creation of new service with this specified.
Tested creation of service that did not specify this.

Add:

```yaml
AWSTemplateFormatVersion: 2010-09-09
...
Metadata:
  AWS::ServiceBroker::Specification:
    ...
    OutputsAsIs: True
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


## Notes

Left as WIP because it doesn't seem to actually work yet - my guess is that the `bool` value type is not persisted as expected between the conversion from yaml to the `map[string]interface{}` within the OSB code.

Will continue next week, out of time for today.