### PR TITLE
fix(helm): remove double quotes

### DIFF
--- a/packaging/helm/aws-servicebroker/templates/broker-deployment.yaml
+++ b/packaging/helm/aws-servicebroker/templates/broker-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - --tlsKey={{ .Values.tls.key }}
         {{- end}}
         - --v={{ .Values.brokerconfig.verbosity }}
-        - --tls-cert-file=/var/run/awssb/awssb.crt"
+        - --tls-cert-file=/var/run/awssb/awssb.crt
         - --tls-private-key-file=/var/run/awssb/awssb.key
         - --region={{ .Values.aws.region }}
         - --s3Bucket={{ .Values.aws.bucket }}


### PR DESCRIPTION
## Overview

I got the following error.

```
F1217 07:39:28.650156       1 main.go:53] open /var/run/awssb/awssb.crt”: no such file or directory
```

It includes unnecessary double quotes at the end of the line.

## Related Issues

Nothing

## Testing

```
$ helm install --namespace aws-sb packaging/helm/aws-servicebroker
```

### Notes

Nothing

## Testing Instructions

```
$ helm install --namespace aws-sb packaging/helm/aws-servicebroker
$ kubectl logs aws-servicebroker-XXXXXXXXXX-XXXXX -n aws-sb
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
