### PR TITLE
Make encryption optionnal for rdspostgresql

### DIFF
--- a/templates/rdspostgresql/template.yaml
+++ b/templates/rdspostgresql/template.yaml
@@ -659,6 +659,10 @@ Conditions:
     !Equals
     - !Ref DBName
     - Auto
+  EncryptionEnabled:
+    !Equals
+    - !Ref StorageEncrypted
+    - 'true'
 Resources:
   DBInstance:
     Type: AWS::RDS::DBInstance
@@ -730,7 +734,11 @@ Resources:
                       - 4000GB
                       - '40000'
                       - '60000'
-      KmsKeyId: !GetAtt KMSKey.Arn
+      KmsKeyId:
+        !If
+        - EncryptionEnabled
+        - !GetAtt KMSKey.Arn
+        - !Ref AWS::NoValue
       LicenseModel: postgresql-license
       MasterUsername: !Ref MasterUsername
       MasterUserPassword:
@@ -886,6 +894,7 @@ Resources:
         - !Ref DBSubnet5
         - !Ref AWS::NoValue
   KMSKey:
+    Condition: EncryptionEnabled
     Type: AWS::KMS::Key
     Properties:
       Description: !Sub Database ${DBName}


### PR DESCRIPTION
## Overview

When setting `StorageEncrypted=false`, the cloudformation template still try to provision an encrypted postgres DB instance, due to KMS key provisionning.

I disabled the KMS key provisionning when `StorageEncrypted=false` in the same way as rdsmysql cloudformation template.

## Related Issues

None

## Testing

```
aws cloudformation create-stack --capabilities CAPABILITY_IAM \
--template-body file://templates/rdspostgresql/template.yaml \
--stack-name rdspostgres-custom-noencryption-test --output json \
--region eu-west-1 \
--parameters ParameterKey=AccessCidr,ParameterValue=10.0.0.0/8 \
ParameterKey=VpcId,ParameterValue=vpc-1234 \
ParameterKey=MasterUsername,ParameterValue=toto \
ParameterKey=StorageEncrypted,ParameterValue=false
```

### Notes

## Testing Instructions

not tested trough aws-servicebroker

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. `yes`
