### PR TITLE
Added helm value for deploying a NamespacedServiceBroker

### DIFF
--- a/docs/getting-started-k8s.md
+++ b/docs/getting-started-k8s.md
@@ -27,6 +27,10 @@ helm repo add aws-sb https://awsservicebroker.s3.amazonaws.com/charts
 helm inspect aws-sb/aws-servicebroker --version 1.0.0-beta.3
 ### Note: If setting aws.targetaccountid on the helm cli, do not use --set, use --set-string, see https://github.com/helm/helm/issues/1707 for more info
 
-# Minimal broker install, assuming defaults above. Add flags to set credentials, region, etc
+# Minimal broker install, assuming defaults above. Sets up a ClusterServiceBroker. Add flags to set credentials, region, etc
 helm install aws-sb/aws-servicebroker --name aws-servicebroker --namespace aws-sb --version 1.0.0-beta.3
+
+# Install broker for the specified namespace only
+helm install aws-sb/aws-servicebroker --name aws-servicebroker --namespace aws-sb --version 1.0.0-beta.3 \
+  --set deployNamespacedServiceBroker=true
 ```

--- a/packaging/helm/aws-servicebroker/templates/_helpers.tpl
+++ b/packaging/helm/aws-servicebroker/templates/_helpers.tpl
@@ -5,5 +5,5 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
-{{- printf "%s" .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/packaging/helm/aws-servicebroker/templates/broker.yaml
+++ b/packaging/helm/aws-servicebroker/templates/broker.yaml
@@ -1,6 +1,10 @@
-{{- if .Values.deployClusterServiceBroker }}
+{{- if or .Values.deployClusterServiceBroker .Values.deployNamespacedServiceBroker }}
 apiVersion: servicecatalog.k8s.io/v1beta1
+{{- if .Values.deployNamespacedServiceBroker }}
+kind: ServiceBroker
+{{- else if .Values.deployClusterServiceBroker }}
 kind: ClusterServiceBroker
+{{- end }}
 metadata:
   name:  "{{ .Release.Name }}"
   labels:

--- a/packaging/helm/aws-servicebroker/values.yaml
+++ b/packaging/helm/aws-servicebroker/values.yaml
@@ -5,6 +5,7 @@ tls:
   cert:
   key:
 deployClusterServiceBroker: true
+deployNamespacedServiceBroker: false
 aws:
   region: us-east-1
   bucket: awsservicebroker


### PR DESCRIPTION
## Overview

Allows the service broker to be deployed as a [Namespaced Service Broker](https://svc-cat.io/docs/namespaced-broker-resources/).

## Related Issues

Fixes #95

## Testing

Validated with `helm template` rendering and deploying to test instance

## Testing Instructions

 * ClusterServiceBroker still default as `deployClusterServiceBroker` is still default value of `true`
 * Deploy namespaced broker by setting `deployNamespacedServiceBroker` to `true`, i.e. `--set deployNamespacedServiceBroker=true`
 * Setting both values to false results in no broker being created

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
