### PR TITLE
Update rds mysql template.yaml

### DIFF
--- a/templates/rdsmysql/template.yaml
+++ b/templates/rdsmysql/template.yaml
@@ -17,6 +17,9 @@ Metadata:
     ImageUrl: https://s3.amazonaws.com/awsservicebroker/icons/AmazonRDS_LARGE.png
     DocumentationUrl: https://aws.amazon.com/documentation/rds/
     ProviderDisplayName: Amazon Web Services
+    Bindings:
+      IAM:
+        AddKeypair: false
     ServicePlans:
       production:
         DisplayName: Production
@@ -566,6 +569,24 @@ Mappings:
       Family: mysql5.7
       MajorVersion: '5.7'
     5.7.17:
+      Family: mysql5.7
+      MajorVersion: '5.7'
+    5.7.18:
+      Family: mysql5.7
+      MajorVersion: '5.7'
+    5.7.19:
+      Family: mysql5.7
+      MajorVersion: '5.7'
+    5.7.20:
+      Family: mysql5.7
+      MajorVersion: '5.7'
+    5.7.21:
+      Family: mysql5.7
+      MajorVersion: '5.7'
+    5.7.22:
+      Family: mysql5.7
+      MajorVersion: '5.7'
+    5.7.23:
       Family: mysql5.7
       MajorVersion: '5.7'
 Conditions:


### PR DESCRIPTION
Added missing Version2Family mappings

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/awslabs/aws-servicebroker/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, add "[WIP]" to the beginning of the PR title
-->

## Overview

This PR patches the RDS MySQL Cloud Formation template by adding the missing family mapping in the cloud formation template

## Related Issues

Failure to provision rds mysql with latest 5.7 family as it cannot find the family mapping 

## Testing

How did you validate the changes in this PR? If there are unit tests included describe what they test

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
