### PR TITLE
New DocumentDB Template for service broker

### DIFF
--- a/templates/auroramysql/template.yaml
+++ b/templates/auroramysql/template.yaml
@@ -201,8 +201,7 @@ Parameters:
   
   AccessCidr:
     Description: CIDR block to allow to connect to database
-    Type: String
-    Default: '172.31.0.0/16'
+    Type: String    
 
   AvailabilityZones:
     Description: list of availability zones to use, must be the same quantity as specified. Leave as Auto for stack to determine AZ names available.      

--- a/templates/documentdb/README.md
+++ b/templates/documentdb/README.md
@@ -1,0 +1,348 @@
+# AWS Service Broker - Amazon DocumentDB (with MongoDB compatibility)
+
+<img align="left" src="https://s3.amazonaws.com/awsservicebroker/icons/aws-service-broker.png" width="120"><img align="right" src=https://s3.amazonaws.com/awsservicebroker/icons/AmazonRDS_LARGE.png width="108"><p align="center">Amazon DocumentDB (with MongoDB compatibility) is a fast, scalable, highly available, and fully managed document database service that supports MongoDB workloads.</p>&nbsp;
+
+Table of contents
+=================
+
+* [Parameters](#parameters)
+  * [production](#param-production)
+  * [dev](#param-dev)
+  * [custom](#param-custom)
+* [Bind Credentials](#bind-credentials)
+* [Examples](#kubernetes-openshift-examples)
+  * [production](#example-production)
+  * [dev](#example-dev)
+  * [custom](#example-custom)
+
+<a id="parameters"></a>
+
+# Parameters
+
+<a id = "param-production"></a>
+
+Creates an Amazon DocumentDB (with MongoDB compatibility) optimised for production use.  
+Pricing: https://aws.amazon.com/documentdb/pricing/
+
+### Required
+
+At a minimum these parameters must be declared when provisioning an instance of this service
+
+Name           | Description     | Accepted Values
+-------------- | --------------- | ---------------
+AccessCidr|CIDR block to allow to connect to database|
+
+### Optional
+
+These parameters can optionally be declared when provisioning
+
+Name            | Description     | Default         | Accepted Values
+--------------- | --------------- | --------------- | ---------------
+DBInstanceClass|Database Instance Class|db.r5.large|db.r4.16xlarge, db.r4.8xlarge, db.r4.4xlarge, db.r4.2xlarge, db.r4.xlarge, db.r4.large, db.r5.24xlarge, db.r5.12xlarge, db.r5.4xlarge, db.r5.2xlarge, db.r5.xlarge, db.r5.large
+PreferredBackupWindow|The daily time range in UTC during which automated backups are created (if automated backups are enabled). Cannot overlap with PreferredMaintenanceWindowTime|00:00-02:00|00:00-02:00, 01:00-03:00, 02:00-04:00, 03:00-05:00, 04:00-06:00, 05:00-07:00, 06:00-08:00, 07:00-09:00, 08:00-10:00, 09:00-11:00, 10:00-12:00, 11:00-13:00, 12:00-14:00, 13:00-15:00, 14:00-16:00, 15:00-17:00, 16:00-18:00, 17:00-19:00, 18:00-20:00, 19:00-21:00, 20:00-22:00, 21:00-23:00, 22:00-24:00
+PreferredMaintenanceWindowDay|The day of the week which Cluster maintenance will be performed|Sun|Mon, Tue, Wed, Thu, Fri, Sat, Sun
+PreferredMaintenanceWindowEndTime|The weekly end time in UTC for the Cluster maintenance window, must be more than PreferredMaintenanceWindowStartTime.|06:00|00:00, 01:00, 02:00, 03:00, 04:00, 05:00, 06:00, 07:00, 08:00, 09:00, 10:00, 11:00, 12:00, 13:00, 14:00, 15:00, 16:00, 17:00, 18:00, 19:00, 20:00, 21:00, 22:00
+PreferredMaintenanceWindowStartTime|The weekly start time in UTC for the Cluster maintenance window, must be less than PreferredMaintenanceWindowEndTime.|04:00|00:00, 01:00, 02:00, 03:00, 04:00, 05:00, 06:00, 07:00, 08:00, 09:00, 10:00, 11:00, 12:00, 13:00, 14:00, 15:00, 16:00, 17:00, 18:00, 19:00, 20:00, 21:00, 22:00
+
+### Generic
+
+These parameters are required, but generic or require privileged access to the underlying AWS account, we recommend they are configured with a broker secret, see [broker documentation](/docs/) for details.
+
+Name            | Description     | Default         | Accepted Values
+--------------- | --------------- | --------------- | ---------------
+target_account_id | AWS Account ID to provision into(optional) ||
+target_role_name | IAM Role name to provision with(optional), must be used in combination with target_account_id ||
+region | AWS Region to create Cluster instance in.| us-west-2 | ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-west-1, eu-west-2, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2
+VpcId|The ID of the VPC to launch the Cluster instance into|
+
+### Prescribed
+
+These are parameters that are prescribed by the plan and are not configurable, should adjusting any of these be required please choose a plan that makes them available.
+
+Name           | Description     | Accepted Values
+-------------- | --------------- | ---------------
+AvailabilityZones|list of availability zones to use, must be the same quantity as specified. Leave as Auto for stack to determine AZ names available.|Auto
+BackupRetentionPeriod|The number of days during which automatic DB snapshots are retained. Min is 1 and Max value is 35.|35
+CidrBlocks|comma seperated list of CIDR blocks to place Cluster into, must be the same quantity as specified in NumberOfAvailabilityZones|Auto
+CidrSize|Size of Cidr block to allocate if CidrBlocks is set to Auto.|27
+DBPort|TCP/IP Port for the Database Instance|27017
+DBUsername|Database master username|master
+DBPassword|Master user database Password, if left at default a 32 character password will be generated|Auto
+NumberOfAvailabilityZones|Quantity of subnets to use, if selecting more than 2 the region this stack is in must have at least that many Availability Zones|3
+NumberofReplicas|Number of Replicas to deploy in addition to the Primary. If selecting 2 replicas, 3 are required in Number Of Availability Zones.|2
+AutoMinorVersionUpgrade|Indicates that minor engine upgrades are applied automatically to the DB instance during the maintenance window.|true
+StorageEncrypted|Indicates whether the DB instance is encrypted.|true
+
+<a id = "param-dev"></a>
+
+Creates an Amazon DocumentDB (with MongoDB compatibility) optimised for dev/test use.  
+Pricing: https://aws.amazon.com/documentdb/pricing/
+
+### Required
+
+At a minimum these parameters must be declared when provisioning an instance of this service
+
+Name           | Description     | Accepted Values
+-------------- | --------------- | ---------------
+AccessCidr|CIDR block to allow to connect to database|
+
+### Optional
+
+These parameters can optionally be declared when provisioning
+
+Name            | Description     | Default         | Accepted Values
+--------------- | --------------- | --------------- | ---------------
+DBInstanceClass|Database Instance Class|db.r5.large|db.r4.16xlarge, db.r4.8xlarge, db.r4.4xlarge, db.r4.2xlarge, db.r4.xlarge, db.r4.large, db.r5.24xlarge, db.r5.12xlarge, db.r5.4xlarge, db.r5.2xlarge, db.r5.xlarge, db.r5.large
+PreferredBackupWindow|The daily time range in UTC during which automated backups are created (if automated backups are enabled). Cannot overlap with PreferredMaintenanceWindowTime|00:00-02:00|00:00-02:00, 01:00-03:00, 02:00-04:00, 03:00-05:00, 04:00-06:00, 05:00-07:00, 06:00-08:00, 07:00-09:00, 08:00-10:00, 09:00-11:00, 10:00-12:00, 11:00-13:00, 12:00-14:00, 13:00-15:00, 14:00-16:00, 15:00-17:00, 16:00-18:00, 17:00-19:00, 18:00-20:00, 19:00-21:00, 20:00-22:00, 21:00-23:00, 22:00-24:00
+PreferredMaintenanceWindowDay|The day of the week which Cluster maintenance will be performed|Sun|Mon, Tue, Wed, Thu, Fri, Sat, Sun
+PreferredMaintenanceWindowEndTime|The weekly end time in UTC for the Cluster maintenance window, must be more than PreferredMaintenanceWindowStartTime.|06:00|00:00, 01:00, 02:00, 03:00, 04:00, 05:00, 06:00, 07:00, 08:00, 09:00, 10:00, 11:00, 12:00, 13:00, 14:00, 15:00, 16:00, 17:00, 18:00, 19:00, 20:00, 21:00, 22:00
+PreferredMaintenanceWindowStartTime|The weekly start time in UTC for the Cluster maintenance window, must be less than PreferredMaintenanceWindowEndTime.|04:00|00:00, 01:00, 02:00, 03:00, 04:00, 05:00, 06:00, 07:00, 08:00, 09:00, 10:00, 11:00, 12:00, 13:00, 14:00, 15:00, 16:00, 17:00, 18:00, 19:00, 20:00, 21:00, 22:00
+
+### Generic
+
+These parameters are required, but generic or require privileged access to the underlying AWS account, we recommend they are configured with a broker secret, see [broker documentation](/docs/) for details.
+
+Name            | Description     | Default         | Accepted Values
+--------------- | --------------- | --------------- | ---------------
+target_account_id | AWS Account ID to provision into(optional) ||
+target_role_name | IAM Role name to provision with(optional), must be used in combination with target_account_id ||
+region | AWS Region to create Cluster instance in.| us-west-2 | ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-west-1, eu-west-2, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2
+VpcId|The ID of the VPC to launch the Cluster instance into|
+
+### Prescribed
+
+These are parameters that are prescribed by the plan and are not configurable, should adjusting any of these be required please choose a plan that makes them available.
+
+Name           | Description     | Accepted Values
+-------------- | --------------- | ---------------
+AvailabilityZones|list of availability zones to use, must be the same quantity as specified. Leave as Auto for stack to determine AZ names available.|Auto
+BackupRetentionPeriod|The number of days during which automatic DB snapshots are retained. Min is 1 and Max value is 35.|0
+CidrBlocks|comma seperated list of CIDR blocks to place Cluster into, must be the same quantity as specified in NumberOfAvailabilityZones|Auto
+CidrSize|Size of Cidr block to allocate if CidrBlocks is set to Auto.|27
+DBPort|TCP/IP Port for the Database Instance|27017
+DBUsername|Database master username|master
+DBPassword|Master user database Password, if left at default a 32 character password will be generated|Auto
+NumberOfAvailabilityZones|Quantity of subnets to use, if selecting more than 2 the region this stack is in must have at least that many Availability Zones|2
+NumberofReplicas|Number of Replicas to deploy in addition to the Primary. If selecting 2 replicas, 3 are required in Number Of Availability Zones.|0
+AutoMinorVersionUpgrade|Indicates that minor engine upgrades are applied automatically to the DB instance during the maintenance window.|true
+StorageEncrypted|Indicates whether the DB instance is encrypted.|true
+PreferredBackupWindow|The daily time range in UTC during which automated backups are created (if automated backups are enabled). Cannot overlap with PreferredMaintenanceWindowTime|00:00-02:00
+PreferredMaintenanceWindowDay|The day of the week which Cluster maintenance will be performed|Sun
+PreferredMaintenanceWindowEndTime|The weekly end time in UTC for the Cluster maintenance window, must be more than PreferredMaintenanceWindowStartTime.|06:00
+PreferredMaintenanceWindowStartTime|The weekly start time in UTC for the Cluster maintenance window, must be less than PreferredMaintenanceWindowEndTime.|04:00
+
+<a id = "param-custom"></a>
+
+Creates an Amazon DocumentDB (with MongoDB compatibility) with custom configuration.  
+Pricing: https://aws.amazon.com/documentdb/pricing/
+
+### Required
+
+At a minimum these parameters must be declared when provisioning an instance of this service
+
+Name           | Description     | Accepted Values
+-------------- | --------------- | ---------------
+AccessCidr|CIDR block to allow to connect to database|
+MasterUsername|Master database Username|string
+
+### Optional
+
+These parameters can optionally be declared when provisioning
+
+Name            | Description     | Default         | Accepted Values
+--------------- | --------------- | --------------- | ---------------
+AccessCidr|CIDR block to allow to connect to database||
+AvailabilityZones|list of availability zones to use, must be the same quantity as specified. Leave as Auto for stack to determine AZ names available.|Auto|
+BackupRetentionPeriod|The number of days during which automatic DB snapshots are retained. Min is 1 and Max value is 35.|35|
+CidrBlocks|comma seperated list of CIDR blocks to place Cluster into, must be the same quantity as specified in NumberOfAvailabilityZones|Auto|
+CidrSize|Size of Cidr block to allocate if CidrBlocks is set to Auto.|27|
+DBPort|TCP/IP Port for the Database Instance|27017|
+DBUsername|Database master username|master|
+DBPassword|Master user database Password, if left at default a 32 character password will be generated|Auto|
+DBEngineVersion|Select Database Engine Version|3.6.0|3.6.0
+DBInstanceClass|Database Instance Class|db.r5.large|db.r4.16xlarge, db.r4.8xlarge, db.r4.4xlarge, db.r4.2xlarge, db.r4.xlarge, db.r4.large, db.r5.24xlarge, db.r5.12xlarge, db.r5.4xlarge, db.r5.2xlarge, db.r5.xlarge, db.r5.large
+NumberOfAvailabilityZones|Quantity of subnets to use, if selecting more than 2 the region this stack is in must have at least that many Availability Zones|2|2, 3, 4, 5
+NumberofReplicas|Number of Replicas to deploy in addition to the Primary. If selecting 2 replicas, 3 are required in Number Of Availability Zones.|0|0, 1, 2
+VpcId|The ID of the VPC to launch the Cluster instance into||
+AutoMinorVersionUpgrade|Indicates that minor engine upgrades are applied automatically to the DB instance during the maintenance window.|true|true, false
+StorageEncrypted|Indicates whether the DB instance is encrypted.|true|true, false
+PreferredBackupWindow|The daily time range in UTC during which automated backups are created (if automated backups are enabled). Cannot overlap with PreferredMaintenanceWindowTime|00:00-02:00|00:00-02:00, 01:00-03:00, 02:00-04:00, 03:00-05:00, 04:00-06:00, 05:00-07:00, 06:00-08:00, 07:00-09:00, 08:00-10:00, 09:00-11:00, 10:00-12:00, 11:00-13:00, 12:00-14:00, 13:00-15:00, 14:00-16:00, 15:00-17:00, 16:00-18:00, 17:00-19:00, 18:00-20:00, 19:00-21:00, 20:00-22:00, 21:00-23:00, 22:00-24:00
+PreferredMaintenanceWindowDay|The day of the week which Cluster maintenance will be performed|Sun|Mon, Tue, Wed, Thu, Fri, Sat, Sun
+PreferredMaintenanceWindowEndTime|The weekly end time in UTC for the Cluster maintenance window, must be more than PreferredMaintenanceWindowStartTime.|06:00|00:00, 01:00, 02:00, 03:00, 04:00, 05:00, 06:00, 07:00, 08:00, 09:00, 10:00, 11:00, 12:00, 13:00, 14:00, 15:00, 16:00, 17:00, 18:00, 19:00, 20:00, 21:00, 22:00
+PreferredMaintenanceWindowStartTime|The weekly start time in UTC for the Cluster maintenance window, must be less than PreferredMaintenanceWindowEndTime.|04:00|00:00, 01:00, 02:00, 03:00, 04:00, 05:00, 06:00, 07:00, 08:00, 09:00, 10:00, 11:00, 12:00, 13:00, 14:00, 15:00, 16:00, 17:00, 18:00, 19:00, 20:00, 21:00, 22:00
+
+### Generic
+
+These parameters are required, but generic or require privileged access to the underlying AWS account, we recommend they are configured with a broker secret, see [broker documentation](/docs/) for details.
+
+Name            | Description     | Default         | Accepted Values
+--------------- | --------------- | --------------- | ---------------
+target_account_id | AWS Account ID to provision into(optional) ||
+target_role_name | IAM Role name to provision with(optional), must be used in combination with target_account_id ||
+region | AWS Region to create Cluster instance in.| us-west-2 | ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-west-1, eu-west-2, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2
+VpcId|The ID of the VPC to launch the Cluster instance into|
+
+<a id="bind-credentials"></a>
+
+# Bind Credentials
+
+These are the environment variables that are available to an application on bind.
+
+Name           | Description
+-------------- | ---------------
+ENDPOINT_ADDRESS|
+MASTER_USERNAME|
+MASTER_PASSWORD|
+PORT|
+
+# Kubernetes/Openshift Examples
+
+***Note:*** Examples do not include generic parameters, if you have not setup defaults for these you will need to add them as additional parameters
+
+<a id ="example-production"></a>
+
+## production
+
+### Minimal
+```yaml
+apiVersion: servicecatalog.k8s.io / v1beta1
+kind: ServiceInstance
+metadata: 
+  name: documentdb-production-complete-example
+spec: 
+  clusterServiceClassExternalName: documentdb
+  clusterServicePlanExternalName: production
+  parameters: 
+    AccessCidr: [VALUE]
+```
+
+### Complete
+```yaml
+apiVersion: servicecatalog.k8s.io / v1beta1
+kind: ServiceInstance
+metadata: 
+  name: documentdb-production-complete-example
+spec: 
+  clusterServiceClassExternalName: documentdb
+  clusterServicePlanExternalName: production
+  parameters: 
+    AccessCidr: [VALUE]
+    AvailabilityZones: Auto
+    BackupRetentionPeriod: 35
+    CidrBlocks: Auto
+    CidrSize: 27
+    DBPort: 27017
+    DBUsername: master
+    DBPassword: Auto
+    DBEngineVersion: 3.6.0
+    DBInstanceClass: db.r5.large
+    NumberOfAvailabilityZones: 3
+    NumberofReplicas: 2  
+    AutoMinorVersionUpgrade: true
+    StorageEncrypted: true
+    PreferredBackupWindow: 00:00-02:00
+    PreferredMaintenanceWindowDay: Sun
+    PreferredMaintenanceWindowEndTime: 06:00
+    PreferredMaintenanceWindowStartTime: 04:00
+```
+
+
+<a id="example-dev"></a>
+
+## dev
+
+### Minimal
+```yaml
+apiVersion: servicecatalog.k8s.io / v1beta1
+kind: ServiceInstance
+metadata: 
+  name: documentdb-dev-complete-example
+spec: 
+  clusterServiceClassExternalName: documentdb
+  clusterServicePlanExternalName: dev
+  parameters: 
+    AccessCidr: [VALUE]
+  
+```
+
+### Complete
+```yaml
+apiVersion: servicecatalog.k8s.io / v1beta1
+kind: ServiceInstance
+metadata: 
+  name: documentdb-dev-complete-example
+spec: 
+  clusterServiceClassExternalName: documentdb
+  clusterServicePlanExternalName: dev
+  parameters: 
+    AccessCidr: [VALUE]
+    AvailabilityZones: Auto
+    BackupRetentionPeriod: 35
+    CidrBlocks: Auto
+    CidrSize: 27
+    DBPort: 27017
+    DBUsername: master
+    DBPassword: Auto
+    DBEngineVersion: 3.6.0
+    DBInstanceClass: db.r5.large
+    NumberOfAvailabilityZones: 2
+    NumberofReplicas: 0    
+    AutoMinorVersionUpgrade: true
+    StorageEncrypted: true
+    PreferredBackupWindow: 00:00-02:00
+    PreferredMaintenanceWindowDay: Sun
+    PreferredMaintenanceWindowEndTime: 06:00
+    PreferredMaintenanceWindowStartTime: 04:00
+```
+
+
+<a id = "example-custom"></a>
+
+## custom
+
+### Minimal
+```yaml
+apiVersion: servicecatalog.k8s.io / v1beta1
+kind: ServiceInstance
+metadata: 
+  name: documentdb-custom-complete-example
+spec: 
+  clusterServiceClassExternalName: documentdb
+  clusterServicePlanExternalName: custom
+  parameters: 
+    AccessCidr: [VALUE]
+    MasterUsername: [VALUE] # REQUIRED
+```
+
+
+### Complete
+```yaml
+apiVersion: servicecatalog.k8s.io / v1beta1
+kind: ServiceInstance
+metadata: 
+  name: documentdb-custom-complete-example
+spec: 
+  clusterServiceClassExternalName: documentdb
+  clusterServicePlanExternalName: custom
+  parameters: 
+    AccessCidr: [VALUE]
+    AvailabilityZones: Auto
+    BackupRetentionPeriod: 35
+    CidrBlocks: Auto
+    CidrSize: 27
+    DBPort: 27017
+    DBUsername: master
+    DBPassword: Auto
+    DBEngineVersion: 3.6.0
+    DBInstanceClass: db.r5.large
+    NumberOfAvailabilityZones: 2
+    NumberofReplicas: 0    
+    AutoMinorVersionUpgrade: true
+    StorageEncrypted: true
+    PreferredBackupWindow: 00:00-02:00
+    PreferredMaintenanceWindowDay: Sun
+    PreferredMaintenanceWindowEndTime: 06:00
+    PreferredMaintenanceWindowStartTime: 04:00
+```
+
+

--- a/templates/documentdb/template.yaml
+++ b/templates/documentdb/template.yaml
@@ -1,0 +1,1056 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'AWS Service Broker - Amazon DocumentDB (with MongoDB compatibility)'
+
+###############################################################################
+# MetaData - ServiceBroker 
+###############################################################################   
+Metadata:
+  AWS::ServiceBroker::Specification:
+    Version: 1.0
+    Tags:
+    - AWS
+    - DocumentDB
+    Name: documentdb
+    DisplayName: Amazon DocumentDB (with MongoDB compatibility)
+    LongDescription: Amazon DocumentDB (with MongoDB compatibility) is a fast, scalable, highly available, and fully managed document database service that supports MongoDB workloads.
+    ImageUrl: https://s3.amazonaws.com/awsservicebroker/icons/AmazonRDS_LARGE.png
+    DocumentationUrl: https://aws.amazon.com/documentdb/
+    ProviderDisplayName: Amazon Web Services
+    ServicePlans:
+      production:
+        DisplayName: Production
+        Description: Configuration designed for production deployments
+        LongDescription: Creates an Amazon DocumentDB optimised for production use
+        Cost: https://aws.amazon.com/documentdb/pricing/
+        ParameterValues:        
+          AvailabilityZones: Auto
+          BackupRetentionPeriod: 35
+          CidrBlocks: Auto
+          CidrSize: 27
+          DBPort: 27017
+          DBUsername: master
+          DBPassword: Auto                
+          NumberOfAvailabilityZones: 3
+          NumberofReplicas: 2        
+          AutoMinorVersionUpgrade: true
+          StorageEncrypted: true        
+      dev:
+        DisplayName: Development
+        Description: Configuration designed for development and testing deployments
+        LongDescription: Creates an Amazon DocumentDB optimised for development use
+        Cost: https://aws.amazon.com/documentdb/pricing/
+        ParameterValues:        
+          AvailabilityZones: Auto
+          BackupRetentionPeriod: 0
+          CidrBlocks: Auto
+          CidrSize: 27
+          DBPort: 27017
+          DBUsername: master
+          DBPassword: Auto
+          NumberOfAvailabilityZones: 2
+          NumberofReplicas: 0        
+          AutoMinorVersionUpgrade: true
+          StorageEncrypted: true
+          PreferredBackupWindow: 00:00-02:00
+          PreferredMaintenanceWindowDay: Sun
+          PreferredMaintenanceWindowEndTime: 06:00
+          PreferredMaintenanceWindowStartTime: 04:00
+      custom:
+        DisplayName: Custom
+        Description: Custom Configuration for Advanced deployments
+        LongDescription: Creates an Amazon DocumentDB optimised for Custom use
+        Cost: https://aws.amazon.com/documentdb/pricing/
+        ParameterValues: {}
+  
+###############################################################################
+# Parameter groups
+###############################################################################
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      -       
+        Label:
+          default: Network and Security
+        Parameters:
+          - VpcId          
+          - PubliclyAccessible
+          - AccessCidr
+          - CidrBlocks
+          - CidrSize
+          - AvailabilityZones
+          - NumberOfAvailabilityZones    
+      -
+        Label:
+          default: Database Instance Specifications
+        Parameters:
+          - DBInstanceClass
+      -
+        Label:
+          default: Database Replication
+        Parameters:     
+          - NumberofReplicas     
+      -
+        Label:
+          default: Database Specification
+        Parameters:                  
+          - DBEngineVersion                                                    
+          - DBPort
+          - DBUsername
+          - DBPassword 
+      -
+        Label:
+          default: Database Parameters
+        Parameters:               
+          - AutoMinorVersionUpgrade              
+          - BackupRetentionPeriod
+          - StorageEncrypted                    
+      -
+        Label:
+          default: Maintainance Parameters
+        Parameters:                     
+          - PreferredBackupWindow
+          - PreferredMaintenanceWindowDay    
+          - PreferredMaintenanceWindowStartTime
+          - PreferredMaintenanceWindowEndTime
+          
+             
+    ParameterLabels:
+      DBUsername:
+        default: Master Username
+      DBPassword:
+        default: Master User Password
+      CidrBlocks:
+        default: CIDR Blocks
+      CidrSize:
+        default: CIDR Size
+      AvailabilityZones:
+        default: Availability Zones
+      NumberOfAvailabilityZones:
+        default: Number Of Availability Zones
+      DBPort:
+        default: Port Number
+      DBInstanceClass:
+        default: DB Instance Class      
+      DBEngineVersion:
+        default: Engine Version
+      VpcId:
+        default: VPC Id     
+      AccessCidr:
+        default: Access CIDR            
+      NumberofReplicas:
+        default: Number of Replicas   
+      PreferredBackupWindow:
+        default: Preferred Backup Window  
+      PreferredMaintenanceWindowDay:
+        default: Preferred Maintenance Window Day
+      PreferredMaintenanceWindowStartTime:
+        default: Preferred Maintenance Window Start Time
+      PreferredMaintenanceWindowEndTime:
+        default: Preferred Maintenance Window End Time
+      AutoMinorVersionUpgrade:
+        default: Auto Minor Version Upgrade      
+      BackupRetentionPeriod:
+        default: Backup Retention Period
+      StorageEncrypted:
+        default: Storage Encrypted
+
+###############################################################################
+# Parameters 
+###############################################################################   
+Parameters:
+  
+  AccessCidr:
+    Description: CIDR block to allow to connect to database
+    Type: String    
+
+  AvailabilityZones:
+    Description: list of availability zones to use, must be the same quantity as specified. Leave as Auto for stack to determine AZ names available.      
+    Type: CommaDelimitedList
+    Default: Auto
+
+  BackupRetentionPeriod:
+    Description: The number of days during which automatic DB snapshots are retained. Min is 1 and Max value is 35.
+    Type: Number
+    Default: '35'
+    MinValue: '1'
+    MaxValue: '35'
+    
+  CidrBlocks:
+    Description: comma seperated list of CIDR blocks to place Cluster into, must be the
+      same quantity as specified in NumberOfAvailabilityZones
+    Type: CommaDelimitedList
+    Default: Auto
+
+  CidrSize:
+    Description: Size of Cidr block to allocate if CidrBlocks is set to Auto.
+    Type: String
+    Default: 27 
+
+  DBPort:
+    Description: TCP/IP Port for the Database Instance
+    Type: Number
+    Default: 27017
+    ConstraintDescription: 'Must be in the range [1150-65535]'
+    MinValue: 1150
+    MaxValue: 65535
+    
+  DBUsername:
+    Description: Database master username
+    Type: String
+    MinLength: '1'
+    MaxLength: '16'
+    AllowedPattern: "^[a-zA-Z]+[0-9a-zA-Z_]*$"
+    ConstraintDescription: Must start with a letter. Only numbers, letters, and _ accepted. max length 16 characters. Note 'admin' is AWS reserved.
+    Default: 'master'
+
+  DBPassword:
+    Description: Master user database Password, if left at default a 32 character password will be generated
+    Type: String
+    Default: Auto
+    NoEcho: 'True'
+
+  DBEngineVersion:
+    Description: Select Database Engine Version
+    Type: String
+    Default: 3.6.0
+    AllowedValues:
+    - 3.6.0
+     
+  DBInstanceClass:
+    Default: db.r5.large
+    Description: Database Instance Class
+    Type: String
+    AllowedValues:  
+    - db.r4.16xlarge
+    - db.r4.8xlarge
+    - db.r4.4xlarge
+    - db.r4.2xlarge
+    - db.r4.xlarge
+    - db.r4.large
+    - db.r5.24xlarge
+    - db.r5.12xlarge
+    - db.r5.4xlarge
+    - db.r5.2xlarge
+    - db.r5.xlarge
+    - db.r5.large
+
+  NumberOfAvailabilityZones:
+    Description: Quantity of subnets to use, if selecting more than 2 the region this
+      stack is in must have at least that many Availability Zones
+    Type: String
+    Default: '2'
+    AllowedValues:        
+    - '2' 
+    - '3'
+    - '4'
+    - '5'
+
+  NumberofReplicas:
+    Description: Number of Replicas to deploy in addition to the Primary. If selecting 2 replicas, 3 are required in Number Of Availability Zones.
+    Type: String
+    Default: '0'
+    AllowedValues:    
+    - '0'
+    - '1'
+    - '2'     
+    
+  VpcId:
+    Description: The ID of the VPC to launch the Cluster instance into
+    Type: AWS::EC2::VPC::Id
+
+  AutoMinorVersionUpgrade:
+    Description: Indicates that minor engine upgrades are applied automatically to
+      the DB instance during the maintenance window.
+    Type: String
+    Default: 'true'
+    AllowedValues:
+    - 'true'
+    - 'false'
+
+  StorageEncrypted:
+    Description: Indicates whether the DB instance is encrypted.
+    Type: String
+    Default: 'true'
+    AllowedValues:
+    - 'true'
+    - 'false'
+
+  PreferredBackupWindow:
+    Description: The daily time range in UTC during which automated backups are created
+      (if automated backups are enabled). Cannot overlap with PreferredMaintenanceWindowTime
+    Type: String
+    Default: 00:00-02:00
+    AllowedValues:
+    - 00:00-02:00
+    - 01:00-03:00
+    - 02:00-04:00
+    - 03:00-05:00
+    - 04:00-06:00
+    - 05:00-07:00
+    - 06:00-08:00
+    - 07:00-09:00
+    - 08:00-10:00
+    - 09:00-11:00
+    - 10:00-12:00
+    - 11:00-13:00
+    - 12:00-14:00
+    - 13:00-15:00
+    - 14:00-16:00
+    - 15:00-17:00
+    - 16:00-18:00
+    - 17:00-19:00
+    - 18:00-20:00
+    - 19:00-21:00
+    - 20:00-22:00
+    - 21:00-23:00
+    - 22:00-24:00
+
+  PreferredMaintenanceWindowDay:
+    Description: The day of the week which Cluster maintenance will be performed
+    Type: String
+    Default: Sun
+    AllowedValues:
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    - Sun
+
+  PreferredMaintenanceWindowEndTime:
+    Description: The weekly end time in UTC for the Cluster maintenance window, must be
+      more than PreferredMaintenanceWindowStartTime.
+    Type: String
+    Default: 06:00
+    AllowedValues:
+    - 00:00
+    - 01:00
+    - 02:00
+    - 03:00
+    - 04:00
+    - 05:00
+    - 06:00
+    - 07:00
+    - 08:00
+    - 09:00
+    - '10:00'
+    - '11:00'
+    - '12:00'
+    - '13:00'
+    - '14:00'
+    - '15:00'
+    - '16:00'
+    - '17:00'
+    - '18:00'
+    - '19:00'
+    - '20:00'
+    - '21:00'
+    - '22:00'
+
+  PreferredMaintenanceWindowStartTime:
+    Description: The weekly start time in UTC for the Cluster maintenance window, must
+      be less than PreferredMaintenanceWindowEndTime.
+    Type: String
+    Default: 04:00
+    AllowedValues:
+    - 00:00
+    - 01:00
+    - 02:00
+    - 03:00
+    - 04:00
+    - 05:00
+    - 06:00
+    - 07:00
+    - 08:00
+    - 09:00
+    - '10:00'
+    - '11:00'
+    - '12:00'
+    - '13:00'
+    - '14:00'
+    - '15:00'
+    - '16:00'
+    - '17:00'
+    - '18:00'
+    - '19:00'
+    - '20:00'
+    - '21:00'
+    - '22:00' 
+  
+          
+###############################################################################
+# Mappings
+###############################################################################
+ 
+Mappings: 
+  DBFamilyMap: 
+    "3.6.0": 
+      "family": "docdb3.6"
+      
+###############################################################################
+# Conditions
+############################################################################### 
+Conditions:  
+  EncryptionEnabled:
+    !Equals
+    - !Ref StorageEncrypted
+    - 'true'
+
+  1replica:
+    !Or
+    - !Equals
+      - !Ref NumberofReplicas
+      - '1'
+    - !Equals
+      - !Ref NumberofReplicas
+      - '2'    
+
+  2replica:
+    !Equals
+    -  !Ref NumberofReplicas
+    - '2'
+
+  3az:
+    !Or
+    - !Equals
+      - !Ref NumberOfAvailabilityZones
+      - '3'
+    - !Equals
+      - !Ref NumberOfAvailabilityZones
+      - '4'
+    - !Equals
+      - !Ref NumberOfAvailabilityZones
+      - '5'
+  4az:
+    !Or
+    - !Equals
+      - !Ref NumberOfAvailabilityZones
+      - '4'
+    - !Equals
+      - !Ref NumberOfAvailabilityZones
+      - '5'
+  5az:
+    !Equals
+    - !Ref NumberOfAvailabilityZones
+    - '5'
+
+  AutoCidrs:
+    !Equals
+    - !Select
+      - 0
+      - !Ref CidrBlocks
+    - Auto
+  AutoAzs:
+    !Equals
+    - !Select
+      - 0
+      - !Ref AvailabilityZones
+    - Auto
+  AutoPassword:
+    !Equals
+    - !Ref DBPassword
+    - Auto 
+
+###############################################################################
+# Resources 
+###############################################################################   
+    
+Resources:      
+  DBCluster:
+    Type: AWS::DocDB::DBCluster
+    DeletionPolicy: Snapshot
+    UpdateReplacePolicy: Snapshot
+    Properties:      
+      EngineVersion: !Ref DBEngineVersion
+      Port: !Ref DBPort
+      MasterUsername: !Ref DBUsername        
+      MasterUserPassword: 
+        !If
+        - AutoPassword
+        - !GetAtt AWSSBInjectedGeneratePassword.MasterUserPassword
+        - !Ref DBPassword  
+      DBSubnetGroupName: !Ref DBSubnetGroup
+      VpcSecurityGroupIds:
+      - !Ref ClusterSecurityGroup  
+      BackupRetentionPeriod: !Ref BackupRetentionPeriod
+      DBClusterParameterGroupName: !Ref RDSDBClusterParameterGroup      
+      StorageEncrypted: !Ref StorageEncrypted      
+      KmsKeyId:  !If
+        - EncryptionEnabled
+        - !GetAtt KMSCMK.Arn
+        - !Ref AWS::NoValue    
+      PreferredBackupWindow: !Ref PreferredBackupWindow  
+      PreferredMaintenanceWindow: !Sub ${PreferredMaintenanceWindowDay}:${PreferredMaintenanceWindowStartTime}-${PreferredMaintenanceWindowDay}:${PreferredMaintenanceWindowEndTime}
+        
+  DBPrimaryInstance:    
+    Type: AWS::DocDB::DBInstance
+    Properties:      
+      DBInstanceClass:
+        Ref: DBInstanceClass
+      DBClusterIdentifier: !Ref DBCluster        
+      AutoMinorVersionUpgrade: !Ref AutoMinorVersionUpgrade            
+      AvailabilityZone:
+        !Select
+        - 0
+        - !If
+          - AutoAzs
+          - !GetAtt AWSSBInjectedGetAzs.AvailabilityZones
+          - !Ref AvailabilityZones
+
+  DBReplicaOneInstance:
+    Condition: 1replica
+    Type: AWS::DocDB::DBInstance
+    Properties:      
+      DBInstanceClass:
+        Ref: DBInstanceClass
+      DBClusterIdentifier: !Ref DBCluster        
+      AutoMinorVersionUpgrade: !Ref AutoMinorVersionUpgrade            
+      AvailabilityZone:
+        !Select
+        - 1
+        - !If
+          - AutoAzs
+          - !GetAtt AWSSBInjectedGetAzs.AvailabilityZones
+          - !Ref AvailabilityZones              
+
+  DBReplicaTwoInstance:
+    Condition: 2replica
+    Type: AWS::DocDB::DBInstance
+    Properties:      
+      DBInstanceClass:
+        Ref: DBInstanceClass
+      DBClusterIdentifier: !Ref DBCluster        
+      AutoMinorVersionUpgrade: !Ref AutoMinorVersionUpgrade            
+      AvailabilityZone:
+        !Select
+        - 2
+        - !If
+          - AutoAzs
+          - !GetAtt AWSSBInjectedGetAzs.AvailabilityZones
+          - !Ref AvailabilityZones
+  
+  RDSDBClusterParameterGroup:
+    Type: AWS::DocDB::DBClusterParameterGroup
+    Properties:
+      Description: !Sub DocDB Parameter Group for Cloudformation Stack ${AWS::StackId}
+      Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"] 
+      Parameters:
+        audit_logs: disabled
+        tls: enabled
+        ttl_monitor: enabled
+
+###############################################################################
+# Network
+###############################################################################  
+  DBSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        !Select
+        - 0
+        - !If
+          - AutoAzs
+          - !GetAtt AWSSBInjectedGetAzs.AvailabilityZones
+          - !Ref AvailabilityZones
+      VpcId: !Ref VpcId
+      CidrBlock:
+        !Select
+        - 0
+        - !If
+          - AutoCidrs
+          - !GetAtt AWSSBInjectedGetCidrs.CidrBlocks
+          - !Ref CidrBlocks
+          
+  DBSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        !Select
+        - 1
+        - !If
+          - AutoAzs
+          - !GetAtt AWSSBInjectedGetAzs.AvailabilityZones
+          - !Ref AvailabilityZones
+      VpcId: !Ref VpcId
+      CidrBlock:
+        !Select
+        - 1
+        - !If
+          - AutoCidrs
+          - !GetAtt AWSSBInjectedGetCidrs.CidrBlocks
+          - !Ref CidrBlocks
+
+  DBSubnet3:
+    Condition: 3az
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        !Select
+        - 2
+        - !If
+          - AutoAzs
+          - !GetAtt AWSSBInjectedGetAzs.AvailabilityZones
+          - !Ref AvailabilityZones
+      VpcId: !Ref VpcId
+      CidrBlock:
+        !Select
+        - 2
+        - !If
+          - AutoCidrs
+          - !GetAtt AWSSBInjectedGetCidrs.CidrBlocks
+          - !Ref CidrBlocks
+
+  DBSubnet4:
+    Condition: 4az
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        !Select
+        - 3
+        - !If
+          - AutoAzs
+          - !GetAtt AWSSBInjectedGetAzs.AvailabilityZones
+          - !Ref AvailabilityZones
+      VpcId: !Ref VpcId
+      CidrBlock:
+        !Select
+        - 3
+        - !If
+          - AutoCidrs
+          - !GetAtt AWSSBInjectedGetCidrs.CidrBlocks
+          - !Ref CidrBlocks
+
+  DBSubnet5:
+    Condition: 5az
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        !Select
+        - 4
+        - !If
+          - AutoAzs
+          - !GetAtt AWSSBInjectedGetAzs.AvailabilityZones
+          - !Ref AvailabilityZones
+      VpcId: !Ref VpcId
+      CidrBlock:
+        !Select
+        - 4
+        - !If
+          - AutoCidrs
+          - !GetAtt AWSSBInjectedGetCidrs.CidrBlocks
+          - !Ref CidrBlocks
+                 
+  DBSubnetGroup:
+    Type: 'AWS::DocDB::DBSubnetGroup'
+    Properties:
+      DBSubnetGroupDescription: !Sub DocDB Cluster
+      SubnetIds:
+      - !Ref DBSubnet1
+      - !Ref DBSubnet2
+      - !If
+        - 3az
+        - !Ref DBSubnet3
+        - !Ref AWS::NoValue
+      - !If
+        - 4az
+        - !Ref DBSubnet4
+        - !Ref AWS::NoValue
+      - !If
+        - 5az
+        - !Ref DBSubnet5
+        - !Ref AWS::NoValue
+              
+  ClusterSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: !Sub Allow Client connections to DocDB Cluster
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: !Ref DBPort
+        ToPort: !Ref DBPort
+        CidrIp: !Ref AccessCidr          
+      SecurityGroupEgress:
+      - IpProtocol: '-1'
+        FromPort: '-1'
+        ToPort: '-1'
+        CidrIp: 0.0.0.0/0       
+      VpcId: !Ref VpcId
+        
+  ClusterSecurityGroupIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      GroupId: !GetAtt 'ClusterSecurityGroup.GroupId'
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref ClusterSecurityGroup
+      Description: 'Self Reference'        
+ 
+###############################################################################
+# Security 
+###############################################################################  
+  KMSCMK:
+    Type: 'AWS::KMS::Key'
+    DeletionPolicy: Retain
+    Properties:
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+          Action: 'kms:*'
+          Resource: '*'
+        - Effect: Allow
+          Principal:
+            AWS: '*'
+          Action:
+          - 'kms:Encrypt'
+          - 'kms:Decrypt'
+          - 'kms:ReEncrypt*'
+          - 'kms:GenerateDataKey*'
+          - 'kms:CreateGrant'
+          - 'kms:ListGrants'
+          - 'kms:DescribeKey'
+          Resource: '*'
+          Condition:
+            StringEquals:
+              'kms:CallerAccount': !Ref 'AWS::AccountId'
+              'kms:ViaService': !Sub 'rds.${AWS::Region}.amazonaws.com'
+
+  KMSCMKAlias:
+    Type: 'AWS::KMS::Alias'
+    DeletionPolicy: Retain
+    DependsOn: DBCluster
+    Properties:
+      AliasName: !Sub 'alias/${DBCluster}'
+      TargetKeyId: !Ref KMSCMK       
+ 
+
+###############################################################################
+# Injected Lambdas
+############################################################################### 
+
+  AWSSBInjectedLambdaZipsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags: []
+  AWSSBInjectedCopyZips:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt AWSSBInjectedCopyZipsLambda.Arn
+      DestBucket: !Ref AWSSBInjectedLambdaZipsBucket
+      SourceBucket: awsservicebrokeralpha
+      Prefix: functions/
+      Objects:
+      - get_cidrs/lambda_function.zip
+      - get_azs/lambda_function.zip
+      - generate_password/lambda_function.zip
+      - generate_dbname/lambda_function.zip
+  AWSSBInjectedCopyZipsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Path: /
+      Policies:
+      - PolicyName: lambda-copier
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Action:
+            - s3:GetObject
+            Resource:
+            - arn:aws:s3:::awsservicebrokeralpha/*
+          - Effect: Allow
+            Action:
+            - s3:PutObject
+            - s3:DeleteObject
+            Resource:
+            - !Sub arn:aws:s3:::${AWSSBInjectedLambdaZipsBucket}/*
+  AWSSBInjectedCopyZipsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Copies objects from a source S3 bucket to a destination
+      Handler: index.handler
+      Runtime: python2.7
+      Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
+      Timeout: 240
+      Code:
+        ZipFile: |
+          import json
+          import logging
+          import threading
+          import boto3
+          import cfnresponse
+
+
+          def copy_objects(source_bucket, dest_bucket, prefix, objects):
+              s3 = boto3.client('s3')
+              for o in objects:
+                  key = prefix + o
+                  copy_source = {
+                      'Bucket': source_bucket,
+                      'Key': key
+                  }
+                  print('copy_source: %s' % copy_source)
+                  print('dest_bucket = %s' % dest_bucket)
+                  print('key = %s' % key)
+                  s3.copy_object(CopySource=copy_source, Bucket=dest_bucket, Key=key)
+
+
+          def delete_objects(bucket, prefix, objects):
+              s3 = boto3.client('s3')
+              objects = {'Objects': [{'Key': prefix + o} for o in objects]}
+              s3.delete_objects(Bucket=bucket, Delete=objects)
+
+
+          def timeout(event, context):
+              logging.error('Execution is about to time out, sending failure response to CloudFormation')
+              cfnresponse.send(event, context, cfnresponse.FAILED, {}, None)
+
+
+          def handler(event, context):
+              timer = threading.Timer((context.get_remaining_time_in_millis() / 1000.00) - 0.5, timeout, args=[event, context])
+              timer.start()
+              print('Received event: %s' % json.dumps(event))
+              status = cfnresponse.SUCCESS
+              try:
+                  source_bucket = event['ResourceProperties']['SourceBucket']
+                  dest_bucket = event['ResourceProperties']['DestBucket']
+                  prefix = event['ResourceProperties']['Prefix']
+                  objects = event['ResourceProperties']['Objects']
+                  if event['RequestType'] == 'Delete':
+                      delete_objects(dest_bucket, prefix, objects)
+                  else:
+                      copy_objects(source_bucket, dest_bucket, prefix, objects)
+              except Exception as e:
+                  logging.error('Exception: %s' % e, exc_info=True)
+                  status = cfnresponse.FAILED
+              finally:
+                  timer.cancel()
+                  cfnresponse.send(event, context, status, {}, None)
+  AWSSBInjectedGetCidrsRole:
+    Condition: AutoCidrs
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: cfn_utility_get_cidrs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - ec2:DescribeVpcs
+            - ec2:DescribeSubnets
+            - ec2:DescribeAvailabilityZones
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: '*'
+  AWSSBInjectedGetCidrsLambda:
+    DependsOn: AWSSBInjectedCopyZips
+    Condition: AutoCidrs
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: lambda_function.handler
+      Role:
+        Fn::GetAtt:
+        - AWSSBInjectedGetCidrsRole
+        - Arn
+      Code:
+        S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
+        S3Key: functions/get_cidrs/lambda_function.zip
+      Runtime: python2.7
+      Timeout: '60'
+  AWSSBInjectedGetCidrs:
+    Condition: AutoCidrs
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt AWSSBInjectedGetCidrsLambda.Arn
+      Qty: !Ref NumberOfAvailabilityZones
+      VpcId: !Ref VpcId
+      CidrSize: !Ref CidrSize
+  AWSSBInjectedGetAzsRole:
+    Condition: AutoAzs
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: cfn_utility_get_cidrs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - ec2:DescribeAvailabilityZones
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: '*'
+  AWSSBInjectedGetAzsLambda:
+    DependsOn: AWSSBInjectedCopyZips
+    Condition: AutoAzs
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: lambda_function.handler
+      Role:
+        Fn::GetAtt:
+        - AWSSBInjectedGetAzsRole
+        - Arn
+      Code:
+        S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
+        S3Key: functions/get_azs/lambda_function.zip
+      Runtime: python2.7
+      Timeout: '60'
+  AWSSBInjectedGetAzs:
+    Condition: AutoAzs
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt AWSSBInjectedGetAzsLambda.Arn
+      Qty: !Ref NumberOfAvailabilityZones
+  AWSSBInjectedGeneratePasswordRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: cfn_utility_get_cidrs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: '*'
+  AWSSBInjectedGeneratePasswordLambda:
+    DependsOn: AWSSBInjectedCopyZips
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: lambda_function.handler
+      Role:
+        Fn::GetAtt:
+        - AWSSBInjectedGeneratePasswordRole
+        - Arn
+      Code:
+        S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
+        S3Key: functions/generate_password/lambda_function.zip
+      Runtime: python3.6
+      Timeout: '60'
+  AWSSBInjectedGeneratePassword:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt AWSSBInjectedGeneratePasswordLambda.Arn
+      Length: 32
+  AWSSBInjectedGenerateDBNameRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: cfn_utility_get_cidrs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: '*'
+  AWSSBInjectedGenerateDBNameLambda:
+    DependsOn: AWSSBInjectedCopyZips
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: lambda_function.handler
+      Role:
+        Fn::GetAtt:
+        - AWSSBInjectedGenerateDBNameRole
+        - Arn
+      Code:
+        S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
+        S3Key: functions/generate_dbname/lambda_function.zip
+      Runtime: python3.6
+      Timeout: '60'
+  AWSSBInjectedGenerateDBName:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt AWSSBInjectedGenerateDBNameLambda.Arn
+      Length: 32
+
+###############################################################################
+# Outputs 
+###############################################################################   
+Outputs:
+  ClusterIdentifier:
+    Description: 'Cluster Id'
+    Value: !GetAtt 'DBCluster.ClusterResourceId'
+  ClusterEndpoint:
+    Description: ' Cluster Writer Endpoint'
+    Value: !GetAtt 'DBCluster.Endpoint'
+  ReaderEndpoint:
+    Description: 'Cluster Reader Endpoint'
+    Value: !GetAtt 'DBCluster.ReadEndpoint'
+  Port:
+    Description: 'Cluster Port'
+    Value: !GetAtt 'DBCluster.Port'
+  InstanceId:
+    Description: 'DB Id'
+    Value: !Ref DBPrimaryInstance  
+  InstanceEndpoint:
+    Description: 'DB Endpoint Port'
+    Value: !GetAtt DBPrimaryInstance.Endpoint
+  DBUsername:
+    Description: 'Database master username'
+    Value: !Ref DBUsername
+  DBPassword:
+   Value:
+      !If
+      - AutoPassword
+      - !GetAtt AWSSBInjectedGeneratePassword.MasterUserPassword
+      - !Ref DBPassword
+ 
+

--- a/templates/rdsoracle/README.md
+++ b/templates/rdsoracle/README.md
@@ -107,6 +107,7 @@ At a minimum these parameters must be declared when provisioning an instance of 
 Name           | Description     | Accepted Values
 -------------- | --------------- | ---------------
 AccessCidr|CIDR block to allow to connect to database|string
+MasterUsername|Master database Username|string
 
 ### Optional
 
@@ -144,6 +145,7 @@ Name            | Description     | Default         | Accepted Values
 target_account_id | AWS Account ID to provision into(optional) ||
 target_role_name | IAM Role name to provision with(optional), must be used in combination with target_account_id ||
 region | AWS Region to create RDS instance in.| us-west-2 | ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-west-1, eu-west-2, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2
+VpcId|The ID of the VPC to launch the RDS instance into||
 
 <a id="bind-credentials"></a>
 


### PR DESCRIPTION
## Overview

1. New DocumentDB template for Service Broker, with ReadMe
2. In OracleRDS Readmemd, missing a param setting in docs
3. In AuroraMySQL, remove the default value on the AccessCIDR

## Testing

Tested DocumentDB launching cluster with 1 and multiple instances (1x Writer 2x Reader)
Tested connection to the endpoints for the cluster.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
