### PR TITLE
Fix casing for Password value from auto to Auto - causing password error

### DIFF
--- a/templates/mq/template.yaml
+++ b/templates/mq/template.yaml
@@ -28,7 +28,7 @@ Metadata:
           CidrSize: 27          
           ConsoleAccess: 'true'
           Username: master
-          Password: auto          
+          Password: Auto          
           EngineVersion: 5.15.9
           InstanceType: mq.m5.large                    
           DeploymentMode: ACTIVE_STANDBY_MULTI_AZ
@@ -46,7 +46,7 @@ Metadata:
           CidrSize: 27       
           ConsoleAccess: 'true'
           Username: master
-          Password: auto                                              
+          Password: Auto                                              
           BrokerName: Auto          
           DeploymentMode: SINGLE_INSTANCE
           AuditLog: 'false'


### PR DESCRIPTION

## Overview
Password is invalid. Enter a password 12 to 250 characters long. (Service: AmazonMQInternal; Status Code: 400; Error Code: BadRequestException; R)

Caused by the value being set to auto instead of Auto in the Service Broker service plans.

Corrected by fixing the AWS::ServiceBroker::Specification ServicePlans in the template

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
