### PR TITLE
allow helm chart to be deployed with an existing secret

### DIFF
--- a/packaging/helm/aws-servicebroker/templates/broker-credentials.yaml
+++ b/packaging/helm/aws-servicebroker/templates/broker-credentials.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.aws.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +12,4 @@ type: Opaque
 data:
   accesskeyid: {{ b64enc .Values.aws.accesskeyid }}
   secretkey: {{ b64enc .Values.aws.secretkey }}
+{{- end }}

--- a/packaging/helm/aws-servicebroker/templates/broker-deployment.yaml
+++ b/packaging/helm/aws-servicebroker/templates/broker-deployment.yaml
@@ -80,13 +80,23 @@ spec:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
+              {{- if .Values.aws.existingSecret }}
+              name: {{ .Values.aws.existingSecret }}
+              key: {{ .Values.aws.accesskeyidName }}
+              {{- else }}
               name: {{ template "fullname" . }}-credentials
               key: accesskeyid
+              {{- end }}
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
+              {{- if .Values.aws.existingSecret }}
+              name: {{ .Values.aws.existingSecret }}
+              key: {{ .Values.aws.secretkeyName }}
+              {{- else }}
               name: {{ template "fullname" . }}-credentials
               key: secretkey
+              {{- end }}
         - name: PARAM_OVERRIDE_{{ .Values.brokerconfig.brokerid }}_all_all_all_region
           value: {{ .Values.aws.region }}
         - name: PARAM_OVERRIDE_{{ .Values.brokerconfig.brokerid }}_all_all_all_VpcId

--- a/packaging/helm/aws-servicebroker/values.yaml
+++ b/packaging/helm/aws-servicebroker/values.yaml
@@ -17,6 +17,9 @@ aws:
   targetaccountid: ""
   targetrolename: ""
   vpcid: ""
+  existingSecret: ""
+  accesskeyidName: "accesskeyid"
+  secretkeyName: "secretkey"
 brokerconfig:
   verbosity: 10
   brokerid: awsservicebroker


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/awslabs/aws-servicebroker/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, add "[WIP]" to the beginning of the PR title
-->

## Overview

In our setup we deploy secret using https://github.com/bitnami-labs/sealed-secrets. For this to work properly helm-charts need to not deploy their own secrets but instead configure their templates to use an existing secret. This PR adds this feature to aws-servicebroker.

## Related Issues

none

## Testing

helm install on a local test-cluster

### Notes

none

## Testing Instructions
```
kubectl create secret ...
helm install -f values.yaml . --name aws-broker-test
```
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
