### PR TITLE
Fix for OpenShift 4 deployment 

### DIFF
--- a/packaging/openshift/deploy.sh
+++ b/packaging/openshift/deploy.sh
@@ -2,8 +2,19 @@
 
 ACCESSKEYID=$(echo -n $1 | base64)
 SECRETKEY=$(echo -n $2 | base64)
-oc new-project aws-sb
+
 # On OpenShift 4.x the project name has changed to "openshift-service-catalog-apiserver"
-oc project kube-service-catalog || oc project openshift-service-catalog-apiserver || echo "Warning: Cannot find project ..."
-CA=`oc get secret                         -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{ index .data "service-ca.crt" }}{{end}}{{"\n"}}{{end}}' | grep -v '^$' | tail -n 1`
-oc process -f aws-servicebroker.yaml --param-file=parameters.env -p BROKER_CA_CERT=$CA -p ACCESSKEYID=${ACCESSKEYID} -p SECRETKEY=${SECRETKEY} | oc apply -f -
+oc projects -q | grep -q "^kube-service-catalog$" && proj=kube-service-catalog
+oc projects -q | grep -q "^openshift-service-catalog-apiserver$" && proj=openshift-service-catalog-apiserver
+[ "$proj" ] || echo "Warning: Cannot find project ..."
+
+# Fetch the cert 
+CA=`oc get secret -n $proj -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{ index .data "service-ca.crt" }}{{end}}{{"\n"}}{{end}}' | grep -v '^$' | tail -n 1`
+
+# Create the project and the AWS Service Broker
+oc new-project aws-sb 
+oc process -f aws-servicebroker.yaml --param-file=parameters.env \
+	--param BROKER_CA_CERT=$CA \
+	--param ACCESSKEYID=${ACCESSKEYID} \
+	--param SECRETKEY=${SECRETKEY} | oc apply -f - -n aws-sb
+

--- a/packaging/openshift/deploy.sh
+++ b/packaging/openshift/deploy.sh
@@ -6,7 +6,7 @@ SECRETKEY=$(echo -n $2 | base64)
 # On OpenShift 4.x the project name has changed to "openshift-service-catalog-apiserver"
 oc projects -q | grep -q "^kube-service-catalog$" && proj=kube-service-catalog
 oc projects -q | grep -q "^openshift-service-catalog-apiserver$" && proj=openshift-service-catalog-apiserver
-[ "$proj" ] || echo "Warning: Cannot find project ..."
+[ ! "$proj" ] && echo "Error: Cannot find project" && exit 1
 
 # Fetch the cert 
 CA=`oc get secret -n $proj -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{ index .data "service-ca.crt" }}{{end}}{{"\n"}}{{end}}' | grep -v '^$' | tail -n 1`


### PR DESCRIPTION
# Overview

PR to fix the deploy.sh script for OpenShift to allow it to work on v4.1 (and should work on 4.2) 
This is a re-fix.  *The script has been tested on 4.1 and 3.11*. 

## Related Issues

The template was being processed into the wrong project.  It should be processed into the awssb project which is created by the deploy.sh script. 
