### PR TITLE
Fix the dynamodb template to support numerical and boolean key attribute types

### DIFF
--- a/templates/dynamodb/ci/config.yml
+++ b/templates/dynamodb/ci/config.yml
@@ -9,7 +9,7 @@ plans:
       HashAttributeName: test
       HashAttributeType: S
       RangeAttributeName: test2
-      RangeAttributeType: S
+      RangeAttributeType: N
       ReadCapacityUnits: 5
       WriteCapacityUnits: 5
     sample_app: dynamodb-sample-app-apb

--- a/templates/dynamodb/template.yaml
+++ b/templates/dynamodb/template.yaml
@@ -94,9 +94,9 @@ Resources:
         KeyType: RANGE
       AttributeDefinitions:
       - AttributeName: !Ref HashAttributeName
-        AttributeType: S
+        AttributeType: !Ref HashAttributeType
       - AttributeName: !Ref RangeAttributeName
-        AttributeType: S
+        AttributeType: !Ref RangeAttributeType
       ProvisionedThroughput:
         ReadCapacityUnits: !Ref ReadCapacityUnits
         WriteCapacityUnits: !Ref WriteCapacityUnits


### PR DESCRIPTION
## Overview

Updated to use the hash and range attribute type input parameters for defining the types in the resource > attribute definitions

## Related Issues

Fixes #164

## Testing Instructions

- Spin up a Kubernetes cluster
- Deploy the AWS service broker (using the updated template for the dynamodb service)
- Provision a table using a Numerical Hash or Range AttributeType
- Check using the AWS console that the table is provisioned with the correct type

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.