### PR TITLE
Fixed the deploy.sh script for openshift 4 - add to release-v1.0.1 branch.  

### DIFF
--- a/packaging/openshift/deploy.sh
+++ b/packaging/openshift/deploy.sh
@@ -2,6 +2,19 @@
 
 ACCESSKEYID=$(echo -n $1 | base64)
 SECRETKEY=$(echo -n $2 | base64)
-oc new-project aws-sb
-CA=`oc get secret -n kube-service-catalog -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{ index .data "service-ca.crt" }}{{end}}{{"\n"}}{{end}}' | grep -v '^$' | tail -n 1`
-oc process -f aws-servicebroker.yaml --param-file=parameters.env -p BROKER_CA_CERT=$CA -p ACCESSKEYID=${ACCESSKEYID} -p SECRETKEY=${SECRETKEY} | oc apply -f -
+
+# On OpenShift 4.x the project name has changed to "openshift-service-catalog-apiserver"
+oc projects -q | grep -q "^kube-service-catalog$" && proj=kube-service-catalog
+oc projects -q | grep -q "^openshift-service-catalog-apiserver$" && proj=openshift-service-catalog-apiserver
+[ ! "$proj" ] && echo "Error: Cannot find project" && exit 1
+
+# Fetch the cert 
+CA=`oc get secret -n $proj -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{ index .data "service-ca.crt" }}{{end}}{{"\n"}}{{end}}' | grep -v '^$' | tail -n 1`
+
+# Create the project and the AWS Service Broker
+oc new-project aws-sb 
+oc process -f aws-servicebroker.yaml --param-file=parameters.env \
+	--param BROKER_CA_CERT=$CA \
+	--param ACCESSKEYID=${ACCESSKEYID} \
+	--param SECRETKEY=${SECRETKEY} | oc apply -f - -n aws-sb
+


### PR DESCRIPTION
## Overview

Fixing the deploy.sh script for OpenShift ... Adding it to release-v1.0.1 branch. 

## Related Issues

This means that the instructions on https://github.com/awslabs/aws-servicebroker/blob/master/docs/getting-started-openshift.md (master) should fetch the correct script. 

## Testing

I tested this curl command returned the correct script content:

curl https://raw.githubusercontent.com/sjbylo/aws-servicebroker/release-v1.0.1/packaging/openshift/deploy.sh
