### PR TITLE
correct documentation to show correct bind credentials for elasticsearch

### DIFF
--- a/templates/elasticsearch/README.md
+++ b/templates/elasticsearch/README.md
@@ -201,7 +201,9 @@ These are the environment variables that are available to an application on bind
 
 Name           | Description
 -------------- | ---------------
-ENDPOINT_ADDRESS
+ELASTICSEARCH_DOMAIN_ARN | The ARN of the Elasticsearch domain.
+ELASTICSEARCH_ENDPOINT | The endpoint address of the Elasticsearch cluster.
+ES_DOMAIN_NAME | The Elasticsearch domain name.
 
 # Kubernetes/Openshift Examples
 


### PR DESCRIPTION
## Overview

The list of provided bind credentails for the elasticsearch service appears to be incorrect, so I have altered the list to the credentials returned by inspecting the binding with svcat.
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
