### PR TITLE
Change to support helm 3 with out accesskeyid and secretkey

### DIFF
--- a/packaging/helm/aws-servicebroker/templates/broker-credentials.yaml
+++ b/packaging/helm/aws-servicebroker/templates/broker-credentials.yaml
@@ -10,6 +10,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  accesskeyid: {{ b64enc .Values.aws.accesskeyid }}
-  secretkey: {{ b64enc .Values.aws.secretkey }}
+  accesskeyid: "{{ b64enc .Values.aws.accesskeyid }}"
+  secretkey: "{{ b64enc .Values.aws.secretkey }}"
 {{- end }}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/awslabs/aws-servicebroker/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, add "[WIP]" to the beginning of the PR title
-->

## Overview

When using target role for authentication helm 3 raises a validation error on generated secrets since accesskeyid and secretkey are blank. Adding the quotes make sure the generated files pass validation


## Related Issues

Fixes https://github.com/awslabs/aws-servicebroker/issues/179

## Testing

Installed aws-servicebroker successfully with modified charts using helm 2 as well as helm 3

### Notes

NA

## Testing Instructions

 * Checkout the branch
 * cd packaging
 * make sure helm 3 is installed and install aws-service broker by running below command
```helm install -n aws-sb aws-servicebroker ./aws-servicebroker --wait --version 1.0.1 --set aws.region=us-east-1 --set aws.targetrolename=aws_service_broker-role```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
