### PR TITLE
Fix typo in EnableLogging description

### DIFF
--- a/templates/s3/template.yaml
+++ b/templates/s3/template.yaml
@@ -122,7 +122,7 @@ Parameters:
     Type: String
     Default: Archive
   EnableLogging:
-    Description: enable or discable S3 logging
+    Description: enable or disable S3 logging
     Type: String
     AllowedValues:
       - 'True'


### PR DESCRIPTION
## Overview

This PR fixes a typo in the description of a stack parameter for provisioning S3 buckets.

## Testing

Textual change to description should not affect any logic.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
