### PR TITLE
helm chart features added for stability and usability

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+entries:
+  aws-servicebroker:
+  - apiVersion: v2
+    appVersion: 1.0.1
+    created: "2020-05-01T11:10:51.935526-06:00"
+    description: Implementation of the Open Service Broker API for AWS. Deploy Cloudformation
+      templates using k8s resources.
+    digest: 4690e4c20b5b81c820e32bffa75a055a01073ea92f7762dfe0901c57e2d2ee2d
+    home: https://aws.amazon.com/partners/servicebroker/
+    keywords:
+    - osbapi
+    - aws
+    - broker
+    name: aws-servicebroker
+    sources:
+    - https://github.com/awslabs/aws-servicebroker.git
+    - https://github.com/kferrone/aws-servicebroker.git
+    urls:
+    - https://github.com/kferrone/aws-servicebroker/releases/download/v1.0.2/aws-servicebroker-1.0.2.tgz
+    version: 1.0.2
+generated: "2020-05-01T11:10:51.934104-06:00"

--- a/packaging/helm/aws-servicebroker/Chart.yaml
+++ b/packaging/helm/aws-servicebroker/Chart.yaml
@@ -1,3 +1,14 @@
+apiVersion: v2
 name: aws-servicebroker
 description: Deploys the AWS Service Broker
-version: 1.0.1
+version: 1.0.2
+appVersion: 1.0.1
+description: Implementation of the Open Service Broker API for AWS. Deploy Cloudformation templates using k8s resources. 
+keywords:
+  - osbapi
+  - aws
+  - broker
+home: https://aws.amazon.com/partners/servicebroker/
+sources:
+  - https://github.com/awslabs/aws-servicebroker.git
+  - https://github.com/kferrone/aws-servicebroker.git

--- a/packaging/helm/aws-servicebroker/templates/_helpers.tpl
+++ b/packaging/helm/aws-servicebroker/templates/_helpers.tpl
@@ -7,3 +7,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "fullname" -}}
 {{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare "<1.9-0" $kubeTargetVersion -}}
+{{- print "apps/v1beta2" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/packaging/helm/aws-servicebroker/templates/broker-deployment.yaml
+++ b/packaging/helm/aws-servicebroker/templates/broker-deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 metadata:
   name: {{ template "fullname" . }}
   labels:
@@ -25,6 +25,10 @@ spec:
 {{- end }}
     spec:
       serviceAccount: {{ template "fullname" . }}-service
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
       containers:
       - name: awssb
         image: {{ .Values.image }}
@@ -98,13 +102,16 @@ spec:
               key: secretkey
               {{- end }}
         - name: PARAM_OVERRIDE_{{ .Values.brokerconfig.brokerid }}_all_all_all_region
-          value: {{ .Values.aws.region }}
+          value: {{ .Values.aws.region | quote }}
         - name: PARAM_OVERRIDE_{{ .Values.brokerconfig.brokerid }}_all_all_all_VpcId
-          value: {{ .Values.aws.vpcid }}
+          value: {{ .Values.aws.vpcid | quote }}
         - name: PARAM_OVERRIDE_{{ .Values.brokerconfig.brokerid }}_all_all_all_target_account_id
-          value: "{{ .Values.aws.targetaccountid }}"
+          value: {{ .Values.aws.targetaccountid | quote }}
         - name: PARAM_OVERRIDE_{{ .Values.brokerconfig.brokerid }}_all_all_all_target_role_name
-          value: {{ .Values.aws.targetrolename }}
+          value: {{ .Values.aws.targetrolename | quote }}
+      {{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+      {{- end }}
       volumes:
       - name: awssb-ssl
         secret:

--- a/packaging/helm/aws-servicebroker/values.yaml
+++ b/packaging/helm/aws-servicebroker/values.yaml
@@ -26,3 +26,13 @@ brokerconfig:
   prescribeoverrides: true
 annotations: {}
 clusterDomain: cluster.local
+
+# Allow overridding the .Capabilities.KubeVersion.GitVersion (useful for "helm template" command)
+kubeTargetVersionOverride: ""
+
+# Add any extra environment variables to the deployment
+extraEnv: []
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}


### PR DESCRIPTION
## Overview

 - added the deployment.apiVersion template commonly used in helm/stable
repos to determine correct apiVersion of deployments
 - added a nodeSelector option on the Deployment
 - added extraEnv array on values so extra environment variables can be
added to the deployment

The apiVersion on the deployment is especially useful for k8s versions 1.16+ since the current chart is using `extensions/v1beta1` which has been completely removed in k8s 1.16 and deprecated since k8s v1.9. 

## Related Issues

Fixes #189 
Fixes: #187 

## Testing

Manually tested with my own values file. Very simple to do and I have written plenty of charts with the same features I just added. 

### Notes

I will be publicly hosting the helm repo on my fork of this project if anyone is interested in using it. 

## Testing Instructions

Simply create a file called `values.yaml` like so:
```yaml
extraEnv: 
  - name: PARAM_OVERRIDE_awsservicebroker_all_all_all_boogie
    value: foo
  - name: PARAM_OVERRIDE_awsservicebroker_all_all_all_woogie
    value: bar

nodeSelector:
  foo: bar

kubeTargetVersionOverride: '1.8'
```
Then run: 
`helm template broker ./packaging/helm/aws-servicebroker/ -f ./values.yaml --debug`
Preview output is to your liking. 
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
