### PR TITLE
update BackupRetentionPeriod minvalue param from 1 to 0

### DIFF
--- a/templates/documentdb/template.yaml
+++ b/templates/documentdb/template.yaml
@@ -171,7 +171,7 @@ Parameters:
     Description: The number of days during which automatic DB snapshots are retained. Min is 1 and Max value is 35.
     Type: Number
     Default: 35
-    MinValue: 1
+    MinValue: 0
     MaxValue: 35
     
   CidrBlocks:


### PR DESCRIPTION

## Overview
Typo in DocumentDB ->BackupRetentionPeriod.
MinValue was 1, updated to allow for 0

## Related Issues
Error reported by user

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
