### PR TITLE
Update Dev plan: BackupRetention Period to 1

### DIFF
--- a/templates/documentdb/template.yaml
+++ b/templates/documentdb/template.yaml
@@ -41,7 +41,7 @@ Metadata:
         Cost: https://aws.amazon.com/documentdb/pricing/
         ParameterValues:        
           AvailabilityZones: Auto
-          BackupRetentionPeriod: 0
+          BackupRetentionPeriod: 1
           CidrBlocks: Auto
           CidrSize: 27
           DBPort: 27017


### PR DESCRIPTION


## Overview

Updating the value in dev pland for BackupRetention from 0 to 1 in inline with minimums per AWS docs for DocumentDb
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
