### PR TITLE
Update Deployment apiVersion

### DIFF
--- a/packaging/openshift/aws-servicebroker.yaml
+++ b/packaging/openshift/aws-servicebroker.yaml
@@ -105,7 +105,7 @@ objects:
     secretkey: ${SECRETKEY}
 
 - kind: Deployment
-  apiVersion: extensions/v1beta1
+  apiVersion: apps/v1
   metadata:
     name: aws-servicebroker
     labels:


### PR DESCRIPTION
Updated "apiVersion: extensions/v1beta1" to "apiVersion: apps/v1" in "kind: Deployment" after receiving the following error: unable to recognize no matches for kind "Deployment" in version "extensions/v1beta1"

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/awslabs/aws-servicebroker/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, add "[WIP]" to the beginning of the PR title
-->

## Overview

Resolve issue with Deployment in OpenShift: unable to recognize no matches for kind "Deployment" in version "extensions/v1beta1"
<img width="308" alt="bstineha_—_bstineha-redhat_com_clientvm___awssb_—_ssh_bstineha-redhat_com_bastion_a044_example_opentlc_com_—_119×60" src="https://user-images.githubusercontent.com/45374847/90626372-37408580-e25e-11ea-8e41-6ed53c1958e8.png">


## Testing

Validated change with successful creation of Deployment (see attached)
<img width="557" alt="Deployments_·_Red_Hat_OpenShift_Container_Platform" src="https://user-images.githubusercontent.com/45374847/90626044-c26d4b80-e25d-11ea-8eb2-7f71ee7b5971.png">
<img width="312" alt="bstineha_—_bstineha-redhat_com_clientvm___awssb_—_ssh_bstineha-redhat_com_bastion_a044_example_opentlc_com_—_119×60" src="https://user-images.githubusercontent.com/45374847/90626591-84bcf280-e25e-11ea-8683-ad27a0d86e49.png">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.