### PR TITLE
Support osb costs convention

### DIFF
--- a/pkg/broker/api.go
+++ b/pkg/broker/api.go
@@ -387,7 +387,7 @@ func (b *AwsBroker) Bind(request *osb.BindRequest, c *broker.RequestContext) (*b
 		// provide them.
 		credentials["INSTANCE_ID"] = binding.InstanceID
 		credentials["BINDING_ID"] = binding.ID
-		
+
 		// Replace credentials with a derived set calculated by a lambda function
 		credentials, err = invokeLambdaBindFunc(sess, b.Clients.NewLambda, credentials, "bind")
 		if err != nil {

--- a/pkg/broker/awsbroker.go
+++ b/pkg/broker/awsbroker.go
@@ -261,6 +261,7 @@ func (db Db) ServiceDefinitionToOsb(sd CfnTemplate) osb.Service {
 			Bindable:    aws.Bool(true),
 			Metadata: map[string]interface{}{
 				"cost":            p.Cost,
+				"costs":           p.Costs,
 				"displayName":     p.DisplayName,
 				"longDescription": p.LongDescription,
 			},

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -178,19 +178,8 @@ type CfnTemplate struct {
 				} `yaml:"IAM,omitempty"`
 				CFNOutputs []string `yaml:"CFNOutputs,omitempty"`
 			} `yaml:"Bindings,omitempty"`
-			ServicePlans map[string]struct {
-				DisplayName       string            `yaml:"DisplayName,omitempty"`
-				Description       string            `yaml:"Description,omitempty"`
-				LongDescription   string            `yaml:"LongDescription,omitempty"`
-				Cost              string            `yaml:"Cost,omitempty"`
-				Costs             []struct {
-					Amount map[string]float64 `yaml:"Amount,omitempty"`
-					Unit string `yaml:"Unit,omitempty"`
-				} `yaml:"Costs,omitempty"`
-				ParameterValues   map[string]string `yaml:"ParameterValues,omitempty"`
-				ParameterDefaults map[string]string `yaml:"ParameterDefaults,omitempty"`
-			} `yaml:"ServicePlans,omitempty"`
-			UpdatableParameters []string `yaml:"UpdatableParameters,omitempty"`
+			ServicePlans        map[string]CfnServicePlan `yaml:"ServicePlans,omitempty"`
+			UpdatableParameters []string               `yaml:"UpdatableParameters,omitempty"`
 		} `yaml:"AWS::ServiceBroker::Specification,omitempty"`
 		Interface struct {
 			ParameterGroups []struct {
@@ -204,6 +193,21 @@ type CfnTemplate struct {
 			} `yaml:"ParameterLabels,omitempty"`
 		} `yaml:"AWS::CloudFormation::Interface,omitempty"`
 	} `yaml:"Metadata,omitempty"`
+}
+
+type CfnServicePlan struct {
+	DisplayName     string `yaml:"DisplayName,omitempty"`
+	Description     string `yaml:"Description,omitempty"`
+	LongDescription string `yaml:"LongDescription,omitempty"`
+	Cost            string `yaml:"Cost,omitempty"`
+	Costs           []CfnCost `yaml:"Costs,omitempty"`
+	ParameterValues   map[string]string `yaml:"ParameterValues,omitempty"`
+	ParameterDefaults map[string]string `yaml:"ParameterDefaults,omitempty"`
+}
+
+type CfnCost struct {
+	Amount map[string]float64 `yaml:"Amount,omitempty"`
+	Unit   string             `yaml:"Unit,omitempty"`
 }
 
 type OpenshiftFormDefinition struct {

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -183,6 +183,10 @@ type CfnTemplate struct {
 				Description       string            `yaml:"Description,omitempty"`
 				LongDescription   string            `yaml:"LongDescription,omitempty"`
 				Cost              string            `yaml:"Cost,omitempty"`
+				Costs             []struct {
+					Amount map[string]float64 `yaml:"Amount,omitempty"`
+					Unit string `yaml:"Unit,omitempty"`
+				} `yaml:"Costs,omitempty"`
 				ParameterValues   map[string]string `yaml:"ParameterValues,omitempty"`
 				ParameterDefaults map[string]string `yaml:"ParameterDefaults,omitempty"`
 			} `yaml:"ServicePlans,omitempty"`

--- a/pkg/broker/types_test.go
+++ b/pkg/broker/types_test.go
@@ -1,0 +1,40 @@
+package broker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestCosts(t *testing.T) {
+	ydoc := []byte(`
+- Amount:
+    EUR: 29.91
+    USD: 30
+  Unit: Monthly
+- Amount: 
+    EUR: 14
+  Unit: Year
+`)
+	var costs []CfnCost
+	err := yaml.Unmarshal(ydoc, &costs)
+	assert.Nil(t, err)
+	assert.Len(t, costs, 2)
+	cost := costs[0]
+	assert.EqualValues(t, CfnCost{
+		Amount: map[string]float64{
+			"EUR": 29.91,
+			"USD": 30.0,
+		},
+		Unit: "Monthly",
+	}, cost)
+	cost = costs[1]
+	assert.EqualValues(t, CfnCost{
+		Amount: map[string]float64{
+			"EUR": 14.0,
+		},
+		Unit: "Year",
+	}, cost)
+
+}


### PR DESCRIPTION
## Overview

Add support for service plan costs defined in the OSB convention by including in the CloudFormation template a "Costs" (note the "s") key alongside the existing "Cost" key in the ServicePlan definition, and by modifying the `Db.ServiceDefinitionToOsb` method to take account of this new key.

I've deliberately left he old "Cost" key because, I assume this was designed to avoid having to update the template every time the costs change upstream.  In this case, we'd like to present costs to our internal customers via Stratos, and we'll need to use the OSB convention instead. 

## Related Issues

Fixes #222 

## Testing

I slightly refactored the `Db.ServiceDefinitionToOsb` method, pulling out a new, private, `Db.servicePlanToOSBPlan` which I was able to directly test via a unit test.  I also added a test to a new types_test.go file, which demonstrates that the Costs structure can be populated from YAML.  Additionally, we're deploying this version into our own CF environment. 

## Testing Instructions

In a cloud formation template you can add, a `Costs` definition like:

```yaml
    ServicePlans:
      production:
        DisplayName: Production
        Description: Configuration designed for production deployments
        LongDescription: Creates an Amazon RDS Microsoft SQL Server Enterprise, Standard, Web and Express optimised for
          production use
        Cost: https://aws.amazon.com/rds/sqlserver/pricing/
        Costs:
          - Amount:
                EUR: 20.01
                USD: 22.50
             Unit: Monthly
          - Amount:
               EUR: 200.99
               USD: 220
            Unit: Yearly
        

```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
