### PR TITLE
Remove dep from Dockerfile as we use modules now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG SOURCE_DIR="./"
 
 COPY $SOURCE_DIR .
 
-RUN dep ensure && make test && make linux
+RUN make test && make linux
 
 FROM alpine:latest
 


### PR DESCRIPTION

## Overview

This PR removes the `dep ensure` step from the Dockerfile as this is no longer required and currently causes the build to fail.

## Related Issues
Fixes #226 

## Testing

I ran:

```docker build -t aws-servicebroker/tealeg-1 .```

... and saw that the build now worked, and tested the resulting image. 

## Testing Instructions

Attempt to run `docker build .` in the root directory of this project.  See that it builds correctly.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
