### PR TITLE
Metric per service and plan

### DIFF
--- a/pkg/broker/api.go
+++ b/pkg/broker/api.go
@@ -46,9 +46,9 @@ func (b *AwsBroker) GetCatalog(c *broker.RequestContext) (*broker.CatalogRespons
 
 	response.CatalogResponse = *osbResponse
 	b.metrics.Actions.With(prom.Labels{
-		"action": "get_catalog",
-		"service": "",
-		"plan": "",
+		"action":  "get_catalog",
+		"service": "", // We have to provide the labels, even when blank.
+		"plan":    "", // Prometheus will omit blank labels.
 	}).Inc()
 	return response, nil
 }
@@ -227,9 +227,9 @@ func (b *AwsBroker) Deprovision(request *osb.DeprovisionRequest, c *broker.Reque
 	}
 
 	labels := prom.Labels{
-		"action": "deprovision",
-		"service": "",
-		"plan": "",
+		"action":  "deprovision",
+		"service": "", // We have to provide the labels, even when blank.
+		"plan":    "", // Prometheus will omit blank labels.
 	}
 
 	// Try to get the service name
@@ -310,9 +310,9 @@ func (b *AwsBroker) LastOperation(request *osb.LastOperationRequest, c *broker.R
 		}
 	}
 	b.metrics.Actions.With(prom.Labels{
-		"action": "last_operation",
-		"service": "",
-		"plan": "",
+		"action":  "last_operation",
+		"service": "", // We have to provide the labels, even when blank.
+		"plan":    "", // Prometheus will omit blank labels.
 	}).Inc()
 	return &response, nil
 }
@@ -444,7 +444,7 @@ func (b *AwsBroker) Bind(request *osb.BindRequest, c *broker.RequestContext) (*b
 		prom.Labels{
 			"action":  "bind",
 			"service": service.Name,
-			"plan": "",
+			"plan":    "",
 		}).Inc()
 
 	return &broker.BindResponse{
@@ -548,7 +548,7 @@ func (b *AwsBroker) Unbind(request *osb.UnbindRequest, c *broker.RequestContext)
 		prom.Labels{
 			"action":  "unbind",
 			"service": service.Name,
-			"plan": "",
+			"plan":    "",
 		}).Inc()
 
 	return &broker.UnbindResponse{}, nil

--- a/pkg/broker/api_test.go
+++ b/pkg/broker/api_test.go
@@ -17,6 +17,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// type MockCounter struct{}
+
+// func (mc *MockCounter) Inc() {
+// 	// Do nothing
+// }
+
+// type MockVec struct{}
+
+// func (mv *MockVec) With(labels *prom.Labels) *MockCounter {
+// 	return &MockCounter{}
+// }
+
+// func NewMockMetricCollector() *MetricsCollector {
+// 	return &MetricsCollector{
+// 		Actions: &MockVec{},
+// 	}
+// }
+
 func TestGetCatalog(t *testing.T) {
 	assertor := assert.New(t)
 
@@ -29,7 +47,7 @@ func TestGetCatalog(t *testing.T) {
 		BrokerID:           "awsservicebroker",
 		PrescribeOverrides: false,
 	}
-	bl, _ := NewAWSBroker(opts, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+	bl, _ := NewAWSBroker(opts, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 	bl.listingcache.Set("__LISTINGS__", []ServiceNeedsUpdate{{Name: "test", Update: false}})
 
 	expected := &broker.CatalogResponse{CatalogResponse: osb.CatalogResponse{}}
@@ -211,7 +229,7 @@ func TestProvision(t *testing.T) {
 		BrokerID:           "awsservicebroker",
 		PrescribeOverrides: true,
 	}
-	bl, _ := NewAWSBroker(opts, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+	bl, _ := NewAWSBroker(opts, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 	bl.db.DataStorePort = mockDataStoreProvision{}
 	bl.globalOverrides = map[string]string{"override_param": "some_value"}
 	provReq := &osb.ProvisionRequest{
@@ -338,7 +356,7 @@ func TestDeprovision(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 			b.db.DataStorePort = mockDataStoreProvision{}
 
 			resp, err := b.Deprovision(tt.request, &broker.RequestContext{})
@@ -461,7 +479,7 @@ func TestLastOperation(t *testing.T) {
 				NewSts: mockAwsStsClientGetter,
 			}
 
-			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, clients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, clients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 			b.db.DataStorePort = mockDataStoreProvision{}
 
 			resp, err := b.LastOperation(tt.request, &broker.RequestContext{Request: &http.Request{Header: http.Header{}}})
@@ -754,7 +772,7 @@ func TestBind(t *testing.T) {
 				NewSts: mockAwsStsClientGetter,
 			}
 
-			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, clients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, clients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 			b.db.DataStorePort = mockDataStoreProvision{}
 
 			resp, err := b.Bind(tt.request, &broker.RequestContext{})
@@ -889,7 +907,7 @@ func TestUnbind(t *testing.T) {
 				NewSts: mockAwsStsClientGetter,
 			}
 
-			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, clients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, clients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 			b.db.DataStorePort = mockDataStoreProvision{}
 			_, err := b.Unbind(tt.request, &broker.RequestContext{})
 			if tt.expectedErr != nil {
@@ -1031,7 +1049,7 @@ func TestUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+			b, _ := NewAWSBroker(Options{}, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 			b.db.DataStorePort = mockDataStoreProvision{}
 
 			resp, err := b.Update(tt.request, &broker.RequestContext{})

--- a/pkg/broker/awsbroker.go
+++ b/pkg/broker/awsbroker.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Runs at startup and bootstraps the broker
-func NewAWSBroker(o Options, awssess GetAwsSession, clients AwsClients, getCallerId GetCallerIder, updateCatalog UpdateCataloger, pollUpdate PollUpdater) (*AwsBroker, error) {
+func NewAWSBroker(o Options, awssess GetAwsSession, clients AwsClients, getCallerId GetCallerIder, updateCatalog UpdateCataloger, pollUpdate PollUpdater, mc *MetricsCollector) (*AwsBroker, error) {
 
 	sess := awssess(o.KeyID, o.SecretKey, o.Region, "", o.Profile, map[string]string{})
 	s3sess := awssess(o.KeyID, o.SecretKey, o.S3Region, "", o.Profile, map[string]string{})
@@ -91,6 +91,7 @@ func NewAWSBroker(o Options, awssess GetAwsSession, clients AwsClients, getCalle
 		Clients:            clients,
 		prescribeOverrides: o.PrescribeOverrides,
 		globalOverrides:    getGlobalOverrides(o.BrokerID),
+		metrics: mc,
 	}
 
 	// get catalog and setup periodic updates from S3

--- a/pkg/broker/awsbroker_test.go
+++ b/pkg/broker/awsbroker_test.go
@@ -234,7 +234,7 @@ func TestNewAwsBroker(t *testing.T) {
 
 	for _, v := range *options {
 		// Shouldn't error
-		bl, err := NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+		bl, err := NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 		assert.Nil(err)
 
 		// check values are as expected
@@ -254,11 +254,11 @@ func TestNewAwsBroker(t *testing.T) {
 		assert.Equal(v.BrokerID, bl.db.Brokerid)
 
 		// Should error
-		_, err = NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountIDFail, mockUpdateCatalog, mockPollUpdate)
+		_, err = NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountIDFail, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 		assert.Error(err)
 
 		// Should error
-		_, err = NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalogFail, mockPollUpdate)
+		_, err = NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalogFail, mockPollUpdate, NewMetricsCollector())
 		assert.Error(err)
 	}
 }
@@ -298,7 +298,7 @@ func TestUpdateCatalog(t *testing.T) {
 	var bl *AwsBroker
 	var bd *BucketDetailsRequest
 	for _, v := range *options {
-		bl, _ = NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+		bl, _ = NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 		bd = &BucketDetailsRequest{
 			v.S3Bucket,
 			v.S3Key,
@@ -385,7 +385,7 @@ func TestMetadataUpdate(t *testing.T) {
 	var bl *AwsBroker
 	var bd *BucketDetailsRequest
 	for _, v := range *options {
-		bl, _ = NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate)
+		bl, _ = NewAWSBroker(v, mockGetAwsSession, mockClients, mockGetAccountID, mockUpdateCatalog, mockPollUpdate, NewMetricsCollector())
 		bd = &BucketDetailsRequest{
 			v.S3Bucket,
 			v.S3Key,

--- a/pkg/broker/metrics.go
+++ b/pkg/broker/metrics.go
@@ -1,0 +1,38 @@
+package broker
+
+import (
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+// MetricsCollector is a prometheus metrics collector that is capable
+// of providing better (more fine grained) action counts that the
+// OSBMetricsCollector provided by the osb-broker-lib library - mainly
+// it exists so that we don't reuse the same metric name, and we don't
+// conflict with the metric gathering in that library.
+type MetricsCollector struct {
+	Actions *prom.CounterVec
+}
+
+
+// New initialises the MetricsCollector with a counter vec.
+func NewMetricsCollector() *MetricsCollector {
+	return &MetricsCollector{
+		Actions: prom.NewCounterVec(prom.CounterOpts{
+			Name: "aws_sb_actions_total",
+			Help: "Total amount of OpenServiceBroker actions requested.",
+		}, []string{"action", "service", "plan"}),
+	}
+}
+
+// Describe returns all descriptions of the collector.
+func (c *MetricsCollector) Describe(ch chan<- *prom.Desc) {
+	c.Actions.Describe(ch)
+}
+
+// Collect returns the current state of all metrics of the collector.
+func (c *MetricsCollector) Collect(ch chan<- prom.Metric) {
+	c.Actions.Collect(ch)
+}
+
+
+

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -69,6 +69,7 @@ type AwsBroker struct {
 	Clients            AwsClients
 	prescribeOverrides bool
 	globalOverrides    map[string]string
+	metrics            *MetricsCollector
 }
 
 // ServiceNeedsUpdate if Update == true the metadata should be refreshed from s3
@@ -179,7 +180,7 @@ type CfnTemplate struct {
 				CFNOutputs []string `yaml:"CFNOutputs,omitempty"`
 			} `yaml:"Bindings,omitempty"`
 			ServicePlans        map[string]CfnServicePlan `yaml:"ServicePlans,omitempty"`
-			UpdatableParameters []string               `yaml:"UpdatableParameters,omitempty"`
+			UpdatableParameters []string                  `yaml:"UpdatableParameters,omitempty"`
 		} `yaml:"AWS::ServiceBroker::Specification,omitempty"`
 		Interface struct {
 			ParameterGroups []struct {
@@ -196,11 +197,11 @@ type CfnTemplate struct {
 }
 
 type CfnServicePlan struct {
-	DisplayName     string `yaml:"DisplayName,omitempty"`
-	Description     string `yaml:"Description,omitempty"`
-	LongDescription string `yaml:"LongDescription,omitempty"`
-	Cost            string `yaml:"Cost,omitempty"`
-	Costs           []CfnCost `yaml:"Costs,omitempty"`
+	DisplayName       string            `yaml:"DisplayName,omitempty"`
+	Description       string            `yaml:"Description,omitempty"`
+	LongDescription   string            `yaml:"LongDescription,omitempty"`
+	Cost              string            `yaml:"Cost,omitempty"`
+	Costs             []CfnCost         `yaml:"Costs,omitempty"`
 	ParameterValues   map[string]string `yaml:"ParameterValues,omitempty"`
 	ParameterDefaults map[string]string `yaml:"ParameterDefaults,omitempty"`
 }


### PR DESCRIPTION
## Overview
This PR adds a new metrics collector to the AWS Service Broker.  Although metrics are already provided by the upstream osb-broker-lib these metrics don't provide any kind of break down by service or plan, which is handy when analysing how customers are using the broker.

## Related Issues
Fixes #224.
Fixes #219

## Testing

How did you validate the changes in this PR? If there are unit tests included describe what they test

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
