### PR TITLE
[WIP] Return correct response for creating instances and bindings that alre…

### DIFF
--- a/pkg/serviceinstance/serviceinstance.go
+++ b/pkg/serviceinstance/serviceinstance.go
@@ -11,8 +11,13 @@ type ServiceInstance struct {
 	StackID   string
 }
 
+// Match returns true if the other service instance has the same attributes.
+// StackID is ignored for correct comparing ServiceInstance got from database and ServiceInstance got from API request
 func (i *ServiceInstance) Match(other *ServiceInstance) bool {
-	return reflect.DeepEqual(i, other)
+	return i.ID == other.ID &&
+		i.ServiceID == other.ServiceID &&
+		i.PlanID == other.PlanID &&
+		reflect.DeepEqual(i.Params, other.Params)
 }
 
 // ServiceBinding represents a service binding.


### PR DESCRIPTION
## Overview

aws-servicebroker does not implement OSB specification correctly. It causes issues with creating K8s service catalog ServiceInstances and ServiceBindings representations for instances and bindings that already exists in broker's database (were created previously with use of plain OSB API).

## Testing

Changes were tested by:
- creating RDS MariaDB and its binding with use of OSB API
- creating RDS MariaDB and its binding with use of OSB API and after that recreating them with use of OSB API
- creating RDS MariaDB and its binding with use of OSB API and after that recreating them with use of K8s service catalog

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
