### PR TITLE
Output keys from OSB costs convention to be lower-case as CF expects

### DIFF
--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -179,7 +179,7 @@ type CfnTemplate struct {
 				CFNOutputs []string `yaml:"CFNOutputs,omitempty"`
 			} `yaml:"Bindings,omitempty"`
 			ServicePlans        map[string]CfnServicePlan `yaml:"ServicePlans,omitempty"`
-			UpdatableParameters []string               `yaml:"UpdatableParameters,omitempty"`
+			UpdatableParameters []string                  `yaml:"UpdatableParameters,omitempty"`
 		} `yaml:"AWS::ServiceBroker::Specification,omitempty"`
 		Interface struct {
 			ParameterGroups []struct {
@@ -196,18 +196,18 @@ type CfnTemplate struct {
 }
 
 type CfnServicePlan struct {
-	DisplayName     string `yaml:"DisplayName,omitempty"`
-	Description     string `yaml:"Description,omitempty"`
-	LongDescription string `yaml:"LongDescription,omitempty"`
-	Cost            string `yaml:"Cost,omitempty"`
-	Costs           []CfnCost `yaml:"Costs,omitempty"`
+	DisplayName       string            `yaml:"DisplayName,omitempty"`
+	Description       string            `yaml:"Description,omitempty"`
+	LongDescription   string            `yaml:"LongDescription,omitempty"`
+	Cost              string            `yaml:"Cost,omitempty"`
+	Costs             []CfnCost         `yaml:"Costs,omitempty"`
 	ParameterValues   map[string]string `yaml:"ParameterValues,omitempty"`
 	ParameterDefaults map[string]string `yaml:"ParameterDefaults,omitempty"`
 }
 
 type CfnCost struct {
-	Amount map[string]float64 `yaml:"Amount,omitempty"`
-	Unit   string             `yaml:"Unit,omitempty"`
+	Amount map[string]float64 `yaml:"Amount,omitempty" json:"amount,omitempty"`
+	Unit   string             `yaml:"Unit,omitempty" json:"unit,omitempty"`
 }
 
 type OpenshiftFormDefinition struct {

--- a/pkg/broker/types_test.go
+++ b/pkg/broker/types_test.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,7 @@ func TestCosts(t *testing.T) {
 	err := yaml.Unmarshal(ydoc, &costs)
 	assert.Nil(t, err)
 	assert.Len(t, costs, 2)
+
 	cost := costs[0]
 	assert.EqualValues(t, CfnCost{
 		Amount: map[string]float64{
@@ -36,5 +38,12 @@ func TestCosts(t *testing.T) {
 		},
 		Unit: "Year",
 	}, cost)
+
+	t.Run("JSON Marshall", func(t *testing.T) {
+		b, err := json.Marshal(costs)
+		assert.Nil(t, err)
+
+		assert.Equal(t, `[{"amount":{"EUR":29.91,"USD":30},"unit":"Monthly"},{"amount":{"EUR":14},"unit":"Year"}]`, string(b))
+	})
 
 }


### PR DESCRIPTION
## Overview

This PR makes a minor correction to the JSON output for a Service Plan in the catalogue.  Previously we added support for the costs convention used by some applications (e.g. Stratos, CloudFoundry).   Unfortunately, we tested this code with clients that were case-insensitive, but in practice CloudFoundry expects the keys "amount" and "unit" to be lowercase.  This PR achieves that by adding JSON annotations to the structure that are used by `encoding/json` when marshalling the struct. 
 
## Related Issues

Fixes #244 

## Testing

I have added a sub-test to the existing unit test which tests that the JSON output format is correct.  

Additionally, I have deployed this in our Cloud Foundry environment and seen that the `cf marketplace -e <service name>` command produces output including the cost data, z.B.: 

```
broker: ocf-aws-services-broker
   plan                    description                  free or paid   costs                                    available
   DevTest                 db.t3.micro / 20GB / No-HA   paid           EUR 15.35/Monthly, USD 18.07/Monthly     yes
   ProdGradeBurstable      db.t3.micro / 20GB / HA      paid           EUR 28.38/Monthly, USD 33.40/Monthly     yes
   ProdGradeNonBurstable   db.m5.large / EBS / HA       paid           EUR 296.38/Monthly, USD 251.81/Monthly   yes
   DevTestNew              db.t3.micro / 20GB / No-HA   paid                                                    no
```


## Testing Instructions

Deploy the service broker to a cloud-foundry foundation.  Add costs data to a service plan, e.g.:

```
        Costs:
        - Amount:
            EUR: 28.38
            USD: 33.40
          Unit: Monthly
```

See that `cf marketplace` reports the price information correctly (see above).  

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
