### PR TITLE
Change python version to 3.9

### DIFF
--- a/templates/athena/template.yaml
+++ b/templates/athena/template.yaml
@@ -184,7 +184,7 @@ Resources:
                   cfnresponse.send(event, context, status, response_data, physical_id)
       Handler: index.lambda_handler
       Role: !GetAtt CreateTableRole.Arn
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: 300
   CreateTableRole:
     Type: AWS::IAM::Role
@@ -306,7 +306,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User

--- a/templates/auroramysql/template.yaml
+++ b/templates/auroramysql/template.yaml
@@ -1125,7 +1125,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -1223,7 +1223,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -1272,7 +1272,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/aurorapostgresql/template.yaml
+++ b/templates/aurorapostgresql/template.yaml
@@ -952,7 +952,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -1050,7 +1050,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -1099,7 +1099,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/cognito/template.yaml
+++ b/templates/cognito/template.yaml
@@ -279,7 +279,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:

--- a/templates/documentdb/template.yaml
+++ b/templates/documentdb/template.yaml
@@ -779,7 +779,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -877,7 +877,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -926,7 +926,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/dynamodb/template.yaml
+++ b/templates/dynamodb/template.yaml
@@ -187,7 +187,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User

--- a/templates/elasticache/template.yaml
+++ b/templates/elasticache/template.yaml
@@ -513,7 +513,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -611,7 +611,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -660,7 +660,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/elasticsearch/template.yaml
+++ b/templates/elasticsearch/template.yaml
@@ -682,7 +682,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -780,7 +780,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -829,7 +829,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/emr/template.yaml
+++ b/templates/emr/template.yaml
@@ -161,7 +161,7 @@ Resources:
   GetIgwFunction:
     Type: AWS::Lambda::Function
     Properties:
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt GetIgwRole.Arn
       Handler: index.handler
       Timeout: 300
@@ -363,7 +363,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -504,7 +504,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_emrcidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetEMRCidr:
     Condition: AutoEMRCidr

--- a/templates/kinesis/template.yaml
+++ b/templates/kinesis/template.yaml
@@ -191,7 +191,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User

--- a/templates/kms/template.yaml
+++ b/templates/kms/template.yaml
@@ -199,7 +199,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User

--- a/templates/lex/template.yaml
+++ b/templates/lex/template.yaml
@@ -119,7 +119,7 @@ Resources:
     Properties:
       Description: Creates Amazon Lex Intents
       Handler: lambda_function.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt LexIntentsRole.Arn
       Timeout: 240
       Code:
@@ -156,7 +156,7 @@ Resources:
     Properties:
       Description: Creates Amazon Lex Custom Slot Types
       Handler: lambda_function.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt LexCustomSlotTypesRole.Arn
       Timeout: 240
       Code:
@@ -193,7 +193,7 @@ Resources:
     Properties:
       Description: Creates Amazon Lex Bot
       Handler: lambda_function.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt LexBotRole.Arn
       Timeout: 240
       Code:
@@ -230,7 +230,7 @@ Resources:
     Properties:
       Description: Creates IAM service linked role
       Handler: lambda_function.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt IamServiceLinkedRoleRole.Arn
       Timeout: 240
       Code:
@@ -349,7 +349,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User
@@ -422,7 +422,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:

--- a/templates/mq/template.yaml
+++ b/templates/mq/template.yaml
@@ -584,7 +584,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -682,7 +682,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -735,7 +735,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/polly/template.yaml
+++ b/templates/polly/template.yaml
@@ -129,7 +129,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User

--- a/templates/rdsmariadb/template.yaml
+++ b/templates/rdsmariadb/template.yaml
@@ -972,7 +972,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -1070,7 +1070,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -1119,7 +1119,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/rdsmssql/template.yaml
+++ b/templates/rdsmssql/template.yaml
@@ -1099,7 +1099,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -1197,7 +1197,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -1246,7 +1246,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/rdsmysql/template.yaml
+++ b/templates/rdsmysql/template.yaml
@@ -1006,7 +1006,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -1104,7 +1104,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -1153,7 +1153,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/rdsoracle/template.yaml
+++ b/templates/rdsoracle/template.yaml
@@ -1308,7 +1308,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -1406,7 +1406,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -1455,7 +1455,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/rdspostgresql/template.yaml
+++ b/templates/rdspostgresql/template.yaml
@@ -1025,7 +1025,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -1123,7 +1123,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -1172,7 +1172,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/redshift/template.yaml
+++ b/templates/redshift/template.yaml
@@ -644,7 +644,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt AWSSBInjectedCopyZipsRole.Arn
       Timeout: 240
       Code:
@@ -742,7 +742,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_cidrs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetCidrs:
     Condition: AutoCidrs
@@ -791,7 +791,7 @@ Resources:
       Code:
         S3Bucket: !Ref AWSSBInjectedLambdaZipsBucket
         S3Key: functions/get_azs/lambda_function.zip
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedGetAzs:
     Condition: AutoAzs

--- a/templates/rekognition/template.yaml
+++ b/templates/rekognition/template.yaml
@@ -114,7 +114,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User

--- a/templates/s3/template.yaml
+++ b/templates/s3/template.yaml
@@ -333,7 +333,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User

--- a/templates/sns/template.yaml
+++ b/templates/sns/template.yaml
@@ -205,7 +205,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User

--- a/templates/sqs/template.yaml
+++ b/templates/sqs/template.yaml
@@ -242,7 +242,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User

--- a/templates/translate/template.yaml
+++ b/templates/translate/template.yaml
@@ -114,7 +114,7 @@ Resources:
                   print(str(e))
                   traceback.print_exc()
                   cfnresponse.send(event, context, cfnresponse.FAILED, response_data, phys_id)
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '60'
   AWSSBInjectedIAMUser:
     Type: AWS::IAM::User


### PR DESCRIPTION
## Overview

This PR update python version for lambdas from 2.7 (that is currently is not supported by AWS) to 3.9

## Related Issues

Since AWS is not supporting lambdas with python 2.7 runtime, AWS service broker should be updated accordingly.

